### PR TITLE
feat(hold): Redis HOLD 취소 기능 구현 (#11)

### DIFF
--- a/src/main/java/com/demo/seatreservation/seat/controller/SeatHoldController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/SeatHoldController.java
@@ -1,5 +1,7 @@
 package com.demo.seatreservation.seat.controller;
 
+import com.demo.seatreservation.seat.dto.request.SeatHoldCancelRequest;
+import com.demo.seatreservation.seat.dto.response.SeatHoldCancelResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +27,14 @@ public class SeatHoldController {
             @Valid @RequestBody SeatHoldRequest request
     ) {
         return ApiResponse.ok(seatHoldService.hold(seatId, request));
+    }
+
+    @DeleteMapping("/{seatId}/hold")
+    public ApiResponse<SeatHoldCancelResponse> cancelHold(
+            @PathVariable Long seatId,
+            @Valid @RequestBody SeatHoldCancelRequest request
+    ) {
+        return ApiResponse.ok(seatHoldService.cancelHold(seatId, request));
     }
 
 }

--- a/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldCancelRequest.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldCancelRequest.java
@@ -1,0 +1,22 @@
+package com.demo.seatreservation.seat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public class SeatHoldCancelRequest {
+
+    @NotNull
+    private Long showId;
+
+    @NotNull
+    private Long userId;
+
+    public SeatHoldCancelRequest() {}
+
+    public Long getShowId() {
+        return showId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/demo/seatreservation/seat/dto/response/SeatHoldCancelResponse.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/response/SeatHoldCancelResponse.java
@@ -1,0 +1,24 @@
+package com.demo.seatreservation.seat.dto.response;
+
+import com.demo.seatreservation.seat.model.SeatRealTimeStatus;
+
+public class SeatHoldCancelResponse {
+
+    private Long seatId;
+    private Long showId;
+    private SeatRealTimeStatus status;
+
+    public SeatHoldCancelResponse(Long seatId, Long showId, SeatRealTimeStatus status) {
+        this.seatId = seatId;
+        this.showId = showId;
+        this.status = status;
+    }
+
+    public static SeatHoldCancelResponse available(Long seatId, Long showId) {
+        return new SeatHoldCancelResponse(seatId, showId, SeatRealTimeStatus.AVAILABLE);
+    }
+
+    public Long getSeatId() { return seatId; }
+    public Long getShowId() { return showId; }
+    public SeatRealTimeStatus getStatus() { return status; }
+}

--- a/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
+++ b/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
@@ -25,4 +25,12 @@ public class HoldRedisRepository {
         Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
         return ttl == null ? -2L : ttl;
     }
+
+    public String getOwner(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
 }

--- a/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
@@ -2,6 +2,8 @@ package com.demo.seatreservation.seat.service;
 
 import java.time.Duration;
 
+import com.demo.seatreservation.seat.dto.request.SeatHoldCancelRequest;
+import com.demo.seatreservation.seat.dto.response.SeatHoldCancelResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +54,31 @@ public class SeatHoldService {
         // 3) TTL 응답
         long expiresInSec = holdRedisRepository.getTtlSec(key);
         return SeatHoldResponse.held(seatId, showId, expiresInSec);
+    }
+
+    @Transactional
+    public SeatHoldCancelResponse cancelHold(Long seatId, SeatHoldCancelRequest request) {
+
+        Long showId = request.getShowId();
+        Long userId = request.getUserId();
+
+        String key = HoldKey.of(showId, seatId);
+
+        // 1. hold 존재 확인
+        String owner = holdRedisRepository.getOwner(key);
+
+        if (owner == null) {
+            throw new BusinessException(ErrorCode.HOLD_EXPIRED);
+        }
+
+        // 2. owner 확인
+        if (!owner.equals(String.valueOf(userId))) {
+            throw new BusinessException(ErrorCode.NOT_HOLD_OWNER);
+        }
+
+        // 3. key 삭제
+        holdRedisRepository.delete(key);
+
+        return SeatHoldCancelResponse.available(seatId, showId);
     }
 }

--- a/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
@@ -2,12 +2,14 @@ package com.demo.seatreservation.seat.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
 import java.util.concurrent.TimeUnit;
 
 import com.demo.seatreservation.domain.Reservation;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
 import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.seat.redis.HoldKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +36,11 @@ class SeatHoldControllerTest {
     void setUp() {
         reservationRepository.deleteAll();
 
+        // Redis 전체 초기화
+        stringRedisTemplate.getConnectionFactory()
+                .getConnection()
+                .flushAll();
+
         // 테스트용 Seat 데이터가 없다면 1개 생성해서 테스트가 항상 돌아가게 준비
         if (seatRepository.count() == 0) {
             Seat seat = Seat.builder()
@@ -55,7 +62,8 @@ class SeatHoldControllerTest {
         long showId = 1L;
         long userId = 100L;
 
-        String key = "hold:" + showId + ":" + seatId;
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
         stringRedisTemplate.delete(key);
 
         mockMvc.perform(
@@ -92,7 +100,8 @@ class SeatHoldControllerTest {
         Long seatId = seatRepository.findAll().get(0).getId();
         long showId = 1L;
 
-        String key = "hold:" + showId + ":" + seatId;
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
         stringRedisTemplate.delete(key);
 
         // 1차 hold (성공)
@@ -123,7 +132,8 @@ class SeatHoldControllerTest {
         Long seatId = seatRepository.findAll().get(0).getId();
         long showId = 1L;
 
-        String key = "hold:" + showId + ":" + seatId;
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
         stringRedisTemplate.delete(key);
 
         // 1차 hold 성공
@@ -136,7 +146,7 @@ class SeatHoldControllerTest {
 
         // TTL을 테스트용으로 1초로 줄여서 만료시키기
         stringRedisTemplate.expire(key, 1, TimeUnit.SECONDS);
-        Thread.sleep(1200);
+        Thread.sleep(1500);
 
         // 만료 후 다시 hold -> 성공해야 정상
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -197,5 +207,106 @@ class SeatHoldControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"showId\": 1}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void cancelHold_success_returnsAvailable() throws Exception {
+        // 테스트 목적:
+        // 1) 정상적인 hold 취소 요청 시 200 OK 반환
+        // 2) Redis hold 키가 삭제되는지 확인
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        long showId = 1L;
+        long userId = 100L;
+
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
+        stringRedisTemplate.delete(key);
+
+        // 먼저 hold 생성
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": %d}
+                    """.formatted(showId, userId)))
+                .andExpect(status().isOk());
+
+        // hold 취소 요청
+        mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": %d}
+                    """.formatted(showId, userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("AVAILABLE"));
+
+        // Redis key 삭제 확인
+        String owner = stringRedisTemplate.opsForValue().get(key);
+        org.junit.jupiter.api.Assertions.assertNull(owner);
+    }
+
+    @Test
+    void cancelHold_notOwner_returns403() throws Exception {
+        // 테스트 목적:
+        // HOLD를 건 사용자와 다른 userId가 취소하려 하면
+        // 403 NOT_HOLD_OWNER가 발생해야 한다
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        long showId = 1L;
+
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
+        stringRedisTemplate.delete(key);
+
+        // user 100이 hold
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": 100}
+                    """.formatted(showId)))
+                .andExpect(status().isOk());
+
+        // user 200이 취소 시도
+        mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": 200}
+                    """.formatted(showId)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void cancelHold_expired_returns409() throws Exception {
+        // 테스트 목적:
+        // HOLD가 이미 만료되었거나 존재하지 않을 때
+        // 409 HOLD_EXPIRED가 발생해야 한다
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        long showId = 1L;
+
+        //String key = "hold:" + showId + ":" + seatId;
+        String key = HoldKey.of(showId, seatId);
+        stringRedisTemplate.delete(key);
+
+        // hold 생성
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": 100}
+                    """.formatted(showId)))
+                .andExpect(status().isOk());
+
+        // TTL 강제 만료
+        stringRedisTemplate.expire(key, 1, TimeUnit.SECONDS);
+        Thread.sleep(1500);
+
+        // 취소 시도
+        mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {"showId": %d, "userId": 100}
+                    """.formatted(showId)))
+                .andExpect(status().isConflict());
     }
 }


### PR DESCRIPTION
실시간 좌석 선점(HOLD) 상태에서 사용자가 선택한 좌석을 해제할 수 있도록
Redis 기반 HOLD 취소 API를 구현하였다.

사용자가 좌석을 잘못 선택하거나 다른 좌석으로 변경하려는 경우
명시적으로 HOLD를 취소하여 좌석 상태를 다시 AVAILABLE로 되돌릴 수 있다.

자세한 설계 구조는 #11 이슈에서 확인

## 통합 테스트
- HOLD 정상 취소 시 Redis key 삭제 확인
- 다른 userId로 취소 시 403 NOT_HOLD_OWNER
- TTL 만료 후 취소 시 409 HOLD_EXPIRED

### 참고
HOLD는 다음 상황에서 해제된다.
- 사용자가 명시적으로 취소한 경우
- TTL 만료 (5분)
- 예약 확정 시 Redis HOLD 삭제