### PR TITLE
[feat/reservation] 좌석 예약 확정(Confirm) API 구현(#16)

### DIFF
--- a/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
@@ -1,0 +1,25 @@
+package com.demo.seatreservation.seat.controller;
+
+import com.demo.seatreservation.common.ApiResponse;
+import com.demo.seatreservation.seat.dto.request.ReservationConfirmRequest;
+import com.demo.seatreservation.seat.dto.response.ReservationConfirmResponse;
+import com.demo.seatreservation.seat.service.ReservationService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reservations")
+public class ReservationConfirmController {
+    private final ReservationService reservationService;
+
+    public ReservationConfirmController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping("/confirm")
+    public ApiResponse<ReservationConfirmResponse> confirm(
+            @Valid @RequestBody ReservationConfirmRequest request
+    ) {
+        return ApiResponse.ok(reservationService.confirm(request));
+    }
+}

--- a/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
@@ -1,0 +1,17 @@
+package com.demo.seatreservation.seat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ReservationConfirmRequest {
+
+    @NotNull
+    private Long seatId;
+
+    @NotNull
+    private Long showId;
+
+    @NotNull
+    private Long userId;
+}

--- a/src/main/java/com/demo/seatreservation/seat/dto/response/ReservationConfirmResponse.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/response/ReservationConfirmResponse.java
@@ -1,0 +1,14 @@
+package com.demo.seatreservation.seat.dto.response;
+
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationConfirmResponse {
+
+    private Long seatId;
+    private Long showId;
+    private ReservationStatus status;
+}

--- a/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
@@ -1,0 +1,74 @@
+package com.demo.seatreservation.seat.service;
+
+import com.demo.seatreservation.global.exception.BusinessException;
+import com.demo.seatreservation.global.exception.ErrorCode;
+import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.seat.dto.request.ReservationConfirmRequest;
+import com.demo.seatreservation.seat.dto.response.ReservationConfirmResponse;
+import com.demo.seatreservation.seat.redis.HoldKey;
+import com.demo.seatreservation.seat.redis.HoldRedisRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReservationService {
+    private final ReservationRepository reservationRepository;
+    private final HoldRedisRepository holdRedisRepository;
+
+    public ReservationService(
+            ReservationRepository reservationRepository,
+            HoldRedisRepository holdRedisRepository
+    ) {
+        this.reservationRepository = reservationRepository;
+        this.holdRedisRepository = holdRedisRepository;
+    }
+
+    @Transactional
+    public ReservationConfirmResponse confirm(ReservationConfirmRequest request) {
+
+        Long seatId = request.getSeatId();
+        Long showId = request.getShowId();
+        Long userId = request.getUserId();
+
+        String holdKey = HoldKey.of(showId, seatId);
+
+        // 1. HOLD 존재 확인
+        String owner = holdRedisRepository.getOwner(holdKey);
+
+        if (owner == null) {
+            throw new BusinessException(ErrorCode.HOLD_EXPIRED);
+        }
+
+        // 2. HOLD 소유자 확인
+        if (!owner.equals(String.valueOf(userId))) {
+            throw new BusinessException(ErrorCode.NOT_HOLD_OWNER);
+        }
+
+        // 3. DB 예약 저장
+        try {
+            Reservation reservation = reservationRepository.save(
+                    Reservation.builder()
+                            .seatId(seatId)
+                            .showId(showId)
+                            .userId(userId)
+                            .status(ReservationStatus.RESERVED)
+                            .build()
+            );
+
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ALREADY_RESERVED);
+        }
+
+        // 4. Redis HOLD 삭제
+        holdRedisRepository.delete(holdKey);
+
+        return ReservationConfirmResponse.builder()
+                .seatId(seatId)
+                .showId(showId)
+                .status(ReservationStatus.RESERVED)
+                .build();
+    }
+}

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
@@ -1,0 +1,194 @@
+package com.demo.seatreservation.seat.controller;
+
+import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.repository.SeatRepository;
+import com.demo.seatreservation.seat.redis.HoldKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ReservationConfirmControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    SeatRepository seatRepository;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 시작 전 DB 예약 데이터 초기화
+        reservationRepository.deleteAll();
+
+        // Redis 전체 초기화 (HOLD 데이터 제거)
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .flushAll();
+
+        // Seat 데이터 초기화
+        seatRepository.deleteAll();
+
+        // 테스트용 좌석 1개 생성
+        seatRepository.save(
+                Seat.builder()
+                        .zone("A")
+                        .row(1)
+                        .number(1)
+                        .build()
+        );
+    }
+
+    @Test
+    void confirm_success_shouldReserveSeat() throws Exception {
+
+        // 테스트 목적:
+        // 1) 정상적인 HOLD 상태에서 예약 확정 요청 시 200 OK 반환
+        // 2) DB에 RESERVED 상태의 예약이 생성되는지 확인
+        // 3) Redis HOLD 키가 삭제되는지 확인
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        Long showId = 1L;
+
+        // Redis HOLD 생성 (사용자 100이 좌석 선점)
+        String key = HoldKey.of(showId, seatId);
+        redisTemplate.opsForValue().set(key, "100");
+
+        // 예약 확정 요청
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {
+                          "seatId": %d,
+                          "showId": %d,
+                          "userId": 100
+                        }
+                        """.formatted(seatId, showId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("RESERVED"));
+
+        // DB에 예약이 생성되었는지 확인
+        Reservation reservation = reservationRepository.findAll().get(0);
+
+        org.junit.jupiter.api.Assertions.assertEquals(ReservationStatus.RESERVED, reservation.getStatus());
+
+        // Redis HOLD 삭제 확인
+        String owner = redisTemplate.opsForValue().get(key);
+        org.junit.jupiter.api.Assertions.assertNull(owner);
+    }
+
+
+    @Test
+    void confirm_withoutHold_shouldReturn409() throws Exception {
+
+        // 테스트 목적:
+        // Redis에 HOLD 키가 존재하지 않는 상태에서
+        // 예약 확정 요청 시 409 HOLD_EXPIRED 에러가 발생해야 한다
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {
+                          "seatId": %d,
+                          "showId": 1,
+                          "userId": 100
+                        }
+                        """.formatted(seatId)))
+                .andExpect(status().isConflict());
+    }
+
+
+    @Test
+    void confirm_notOwner_shouldReturn403() throws Exception {
+
+        // 테스트 목적:
+        // HOLD를 건 사용자와 다른 userId가 예약 확정을 시도할 경우
+        // 403 NOT_HOLD_OWNER 에러가 발생해야 한다
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        Long showId = 1L;
+
+        // Redis HOLD 생성 (user 200이 선점)
+        String key = HoldKey.of(showId, seatId);
+        redisTemplate.opsForValue().set(key, "200");
+
+        // user 100이 예약 확정 시도
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {
+                          "seatId": %d,
+                          "showId": %d,
+                          "userId": 100
+                        }
+                        """.formatted(seatId, showId)))
+                .andExpect(status().isForbidden());
+    }
+
+
+    @Test
+    void confirm_twice_shouldReturnAlreadyReserved() throws Exception {
+
+        // 테스트 목적:
+        // 동일 좌석에 대해 예약 확정을 두 번 시도할 경우
+        // 두 번째 요청은 409 ALREADY_RESERVED 에러가 발생해야 한다
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        Long showId = 1L;
+
+        String key = HoldKey.of(showId, seatId);
+
+        // 첫 번째 HOLD 생성
+        redisTemplate.opsForValue().set(key, "100");
+
+        // 첫 번째 confirm (성공)
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {
+                          "seatId": %d,
+                          "showId": %d,
+                          "userId": 100
+                        }
+                        """.formatted(seatId, showId)))
+                .andExpect(status().isOk());
+
+        // 두 번째 confirm을 위해 다시 HOLD 생성
+        redisTemplate.opsForValue().set(key, "100");
+
+        // 두 번째 confirm (이미 예약됨 → 실패)
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                        {
+                          "seatId": %d,
+                          "showId": %d,
+                          "userId": 100
+                        }
+                        """.formatted(seatId, showId)))
+                .andExpect(status().isConflict());
+    }
+}


### PR DESCRIPTION
Redis HOLD 상태의 좌석을 최종 예약 확정할 수 있는 Confirm API를 구현하였다.

사용자는 좌석을 HOLD한 후 일정 시간 내에 예약을 확정해야 하며,
예약 확정 시 DB에 RESERVED 상태로 저장되고 Redis HOLD는 삭제된다.

이를 통해 좌석 상태는 다음 흐름을 따른다.
```
AVAILABLE → HELD → RESERVED
```
자세한 설계 구조는 #16 이슈에서 확인

통합 테스트 
- HOLD 상태에서 confirm 성공 시 DB RESERVED 저장 확인
- confirm 성공 시 Redis HOLD 키 삭제 확인
- HOLD 없이 confirm 시 409 HOLD_EXPIRED
- 다른 user confirm 시 403 NOT_HOLD_OWNER
- 동일 좌석 confirm 두 번 시도 시 409 ALREADY_RESERVED