### PR TITLE
[feat/get-my-reservations] 내 예약 조회 API 구현 (#19)

### DIFF
--- a/src/main/java/com/demo/seatreservation/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/demo/seatreservation/global/exception/handler/GlobalExceptionHandler.java
@@ -7,9 +7,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -51,6 +53,42 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 필수 RequestParam 누락 처리
+     *
+     * - ex) userId 누락
+     * - 400 VALIDATION_ERROR 반환
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParam(
+            MissingServletRequestParameterException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+
+        return ResponseEntity
+                .status(code.httpStatus())
+                .body(ErrorResponse.of(code.name(), code.message(), request.getRequestURI()));
+    }
+
+    /**
+     * RequestParam 타입 불일치 처리
+     *
+     * - ex) userId=abc (Long 타입 불일치)
+     * - 400 VALIDATION_ERROR 반환
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(
+            MethodArgumentTypeMismatchException e,
+            HttpServletRequest request
+    ) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+
+        return ResponseEntity
+                .status(code.httpStatus())
+                .body(ErrorResponse.of(code.name(), code.message(), request.getRequestURI()));
+    }
+
+    /**
      * DB 제약 조건 위반 처리
      *
      * - UNIQUE 제약 충돌 시 발생
@@ -89,4 +127,6 @@ public class GlobalExceptionHandler {
                 .status(500)
                 .body(ErrorResponse.of("INTERNAL_SERVER_ERROR", "서버 오류", request.getRequestURI()));
     }
+
+
 }

--- a/src/main/java/com/demo/seatreservation/repository/ReservationRepository.java
+++ b/src/main/java/com/demo/seatreservation/repository/ReservationRepository.java
@@ -13,9 +13,7 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     /**
-     * 특정 공연(showId) + 좌석(seatId)에
-     * 이미 RESERVED 상태의 예약이 있는지 확인
-     *
+     * 특정 공연(showId) + 좌석(seatId)에 RESERVED 예약 존재 여부 확인
      * → ALREADY_RESERVED 판단용
      */
     boolean existsByShowIdAndSeatIdAndStatus(
@@ -26,8 +24,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     /**
      * 특정 공연(showId)에서 RESERVED 상태인 좌석 ID 목록 조회
-     *
-     * → 좌석 조회 시 RESERVED 상태 계산용
+     * → 좌석 조회 API에서 좌석의 RESERVED 상태를 판단하기 위해 사용
      */
     @Query("""
         select r.seatId
@@ -36,4 +33,16 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
           and r.status = :status
     """)
     List<Long> findSeatIdsByShowIdAndStatus(Long showId, ReservationStatus status);
+
+    /**
+     * 특정 사용자의 상태별 예약 조회
+     * → 내 예약 조회 (status 필터)
+     */
+    List<Reservation> findByUserIdAndStatus(Long userId, ReservationStatus status);
+
+    /**
+     * 특정 사용자의 모든 예약 조회
+     * → 내 예약 조회 기본 (예약 확정, 예약 취소 둘 다 나옴)
+     */
+    List<Reservation> findByUserId(Long userId);
 }

--- a/src/main/java/com/demo/seatreservation/seat/controller/ReservationQueryController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/ReservationQueryController.java
@@ -1,0 +1,34 @@
+package com.demo.seatreservation.seat.controller;
+
+import com.demo.seatreservation.common.ApiResponse;
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.seat.dto.response.MyReservationResponse;
+import com.demo.seatreservation.seat.service.ReservationQueryService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 내 예약 조회 API
+ */
+@RestController
+@RequestMapping("/api/me")
+public class ReservationQueryController {
+
+    private final ReservationQueryService reservationQueryService;
+
+    public ReservationQueryController(ReservationQueryService reservationQueryService) {
+        this.reservationQueryService = reservationQueryService;
+    }
+
+    // 내 예약 조회 (status 필터 선택 가능)
+    @GetMapping("/reservations")
+    public ApiResponse<List<MyReservationResponse>> getMyReservations(
+            @RequestParam Long userId,
+            @RequestParam(required = false) ReservationStatus status
+    ) {
+        return ApiResponse.ok(
+                reservationQueryService.getMyReservations(userId, status)
+        );
+    }
+}

--- a/src/main/java/com/demo/seatreservation/seat/dto/response/MyReservationResponse.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/response/MyReservationResponse.java
@@ -1,0 +1,18 @@
+package com.demo.seatreservation.seat.dto.response;
+
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyReservationResponse {
+
+    private Long reservationId;
+    private Long seatId;
+    private Long showId;
+    private ReservationStatus status;
+    private LocalDateTime reservedAt;
+}

--- a/src/main/java/com/demo/seatreservation/seat/service/ReservationQueryService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/ReservationQueryService.java
@@ -1,0 +1,49 @@
+package com.demo.seatreservation.seat.service;
+
+import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.seat.dto.response.MyReservationResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 내 예약 조회 서비스
+ */
+@Service
+@Transactional(readOnly = true)
+public class ReservationQueryService {
+
+    private final ReservationRepository reservationRepository;
+
+    public ReservationQueryService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
+
+    // 사용자 예약 목록 조회
+    public List<MyReservationResponse> getMyReservations(Long userId, ReservationStatus status) {
+
+        List<Reservation> reservations;
+
+        // status 값이 있으면 해당 상태로 필터링하여 조회
+        if (status != null) {
+            reservations = reservationRepository.findByUserIdAndStatus(userId, status);
+        }
+        // status 값이 없으면 사용자의 전체 예약 조회
+        else {
+            reservations = reservationRepository.findByUserId(userId);
+        }
+
+        return reservations.stream()
+                .map(r -> MyReservationResponse.builder()
+                        .reservationId(r.getId())
+                        .seatId(r.getSeatId())
+                        .showId(r.getShowId())
+                        .status(r.getStatus())
+                        .reservedAt(r.getReservedAt())
+                        .build())
+                .toList();
+    }
+}

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
@@ -1,0 +1,201 @@
+package com.demo.seatreservation.seat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.repository.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReservationQueryControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ReservationRepository reservationRepository;
+    @Autowired SeatRepository seatRepository;
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 데이터 초기화
+        reservationRepository.deleteAll();
+        seatRepository.deleteAll();
+
+        // 좌석 2개 생성 (UNIQUE 충돌 방지)
+        seatRepository.save(
+                Seat.builder()
+                        .zone("A")
+                        .row(1)
+                        .number(1)
+                        .build()
+        );
+
+        seatRepository.save(
+                Seat.builder()
+                        .zone("A")
+                        .row(1)
+                        .number(2)
+                        .build()
+        );
+    }
+
+    @Test
+    void getMyReservations_returnsUserReservations() throws Exception {
+
+        // 테스트 목적:
+        // 특정 userId로 예약 조회 시
+        // 해당 사용자의 예약 목록이 정상적으로 반환되는지 확인
+
+        Long seatId = seatRepository.findAll().get(0).getId();
+        long showId = 1L;
+        long userId = 100L;
+
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatId)
+                        .showId(showId)
+                        .userId(userId)
+                        .status(ReservationStatus.RESERVED)
+                        .build()
+        );
+
+        mockMvc.perform(
+                        get("/api/me/reservations")
+                                .param("userId", String.valueOf(userId))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].seatId").value(seatId))
+                .andExpect(jsonPath("$.data[0].showId").value((int) showId))
+                .andExpect(jsonPath("$.data[0].status").value("RESERVED"));
+    }
+
+    @Test
+    void getMyReservations_withStatusFilter_returnsFilteredReservations() throws Exception {
+
+        // 테스트 목적:
+        // status 필터가 있을 경우
+        // 해당 상태의 예약만 조회되는지 확인
+
+        Long seatId1 = seatRepository.findAll().get(0).getId();
+        Long seatId2 = seatRepository.findAll().get(1).getId();
+
+        long showId = 1L;
+        long userId = 100L;
+
+        // RESERVED 예약
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatId1)
+                        .showId(showId)
+                        .userId(userId)
+                        .status(ReservationStatus.RESERVED)
+                        .build()
+        );
+
+        // CANCELED 예약
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatId2)
+                        .showId(showId)
+                        .userId(userId)
+                        .status(ReservationStatus.CANCELED)
+                        .build()
+        );
+
+        mockMvc.perform(
+                        get("/api/me/reservations")
+                                .param("userId", String.valueOf(userId))
+                                .param("status", "RESERVED")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].status").value("RESERVED"));
+    }
+
+    @Test
+    void getMyReservations_emptyResult_returnsEmptyList() throws Exception {
+
+        // 테스트 목적:
+        // 해당 userId의 예약이 없을 경우
+        // 빈 리스트가 반환되는지 확인
+
+        long userId = 999L;
+
+        mockMvc.perform(
+                        get("/api/me/reservations")
+                                .param("userId", String.valueOf(userId))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void getMyReservations_missingUserId_returns400() throws Exception {
+
+        // 테스트 목적:
+        // userId는 필수 파라미터이므로
+        // 누락 시 400 Bad Request가 발생해야 한다
+
+        mockMvc.perform(
+                        get("/api/me/reservations")
+                )
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getMyReservations_excludesOtherUsersReservations() throws Exception {
+
+        // 테스트 목적:
+        // 다른 사용자의 예약은 조회되지 않아야 한다
+
+        Long seatId1 = seatRepository.findAll().get(0).getId();
+        Long seatId2 = seatRepository.findAll().get(1).getId();
+
+        long showId = 1L;
+
+        long userId1 = 100L;
+        long userId2 = 200L;
+
+        // userId=100 예약
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatId1)
+                        .showId(showId)
+                        .userId(userId1)
+                        .status(ReservationStatus.RESERVED)
+                        .build()
+        );
+
+        // userId=200 예약
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatId2)
+                        .showId(showId)
+                        .userId(userId2)
+                        .status(ReservationStatus.RESERVED)
+                        .build()
+        );
+
+        mockMvc.perform(
+                        get("/api/me/reservations")
+                                .param("userId", String.valueOf(userId1))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].seatId").value(seatId1));
+    }
+}


### PR DESCRIPTION
사용자가 본인의 예약 목록을 조회할 수 있는 API를 구현하였다.

자세한 설계 구조는 #19 이슈에서 확인

통합 테스트
- 기본 조회
- status 필터 조회 (RESERVED or CANCELED)
- 예약이 없는 경우
- userId가 누락된 경우
- 다른 사용자의 예약 내역을 조회되지 않아야 함