### PR TITLE
[feat/hold-limit] 좌석 HOLD 4개 제한 및 사용자별 Redis HOLD 관리 구현 (#23)

### DIFF
--- a/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
+++ b/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소됨"),
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이메일 중복"),
     SEAT_DUPLICATED(HttpStatus.CONFLICT, "동일 좌석(구역/행/번호) 중복"),
-    SEAT_RESERVED_CANNOT_DELETE(HttpStatus.CONFLICT, "예약 확정 좌석 삭제 불가");
+    SEAT_RESERVED_CANNOT_DELETE(HttpStatus.CONFLICT, "예약 확정 좌석 삭제 불가"),
+    HOLD_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "좌석은 최대 4개까지 선택 가능");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
+++ b/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
@@ -33,4 +33,21 @@ public class HoldRedisRepository {
     public void delete(String key) {
         redisTemplate.delete(key);
     }
+
+    // 사용자 HOLD 개수 조회
+    public Long getUserHoldCount(String userHoldKey) {
+        return redisTemplate.opsForSet().size(userHoldKey);
+    }
+
+    // 사용자 HOLD 추가
+    public void addUserHold(String userHoldKey, Long seatId, Duration ttl) {
+        redisTemplate.opsForSet().add(userHoldKey, String.valueOf(seatId));
+        redisTemplate.expire(userHoldKey, ttl);
+    }
+
+    // 사용자 HOLD 제거
+    public void removeUserHold(String userHoldKey, Long seatId) {
+        redisTemplate.opsForSet().remove(userHoldKey, String.valueOf(seatId));
+    }
+
 }

--- a/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
@@ -66,6 +66,9 @@ public class ReservationService {
         // 4. Redis HOLD 삭제
         holdRedisRepository.delete(holdKey);
 
+        String userHoldKey = "hold:user:" + showId + ":" + userId;
+        holdRedisRepository.removeUserHold(userHoldKey, seatId);
+
         return ReservationConfirmResponse.builder()
                 .seatId(seatId)
                 .showId(showId)

--- a/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
@@ -43,7 +43,16 @@ public class SeatHoldService {
             throw new BusinessException(ErrorCode.ALREADY_RESERVED);
         }
 
-        // 2) Redis NX + TTL hold
+        // 2) 사용자 HOLD 제한
+        String userHoldKey = "hold:user:" + showId + ":" + userId;
+
+        Long count = holdRedisRepository.getUserHoldCount(userHoldKey);
+
+        if (count != null && count >= 4) {
+            throw new BusinessException(ErrorCode.HOLD_LIMIT_EXCEEDED);
+        }
+
+        // 3) Redis NX + TTL hold
         String key = HoldKey.of(showId, seatId);
         boolean ok = holdRedisRepository.tryHold(key, String.valueOf(userId), HOLD_TTL);
 
@@ -51,7 +60,9 @@ public class SeatHoldService {
             throw new BusinessException(ErrorCode.SEAT_ALREADY_HELD);
         }
 
-        // 3) TTL 응답
+        holdRedisRepository.addUserHold(userHoldKey, seatId, HOLD_TTL);
+
+        // 4) TTL 응답
         long expiresInSec = holdRedisRepository.getTtlSec(key);
         return SeatHoldResponse.held(seatId, showId, expiresInSec);
     }
@@ -63,6 +74,7 @@ public class SeatHoldService {
         Long userId = request.getUserId();
 
         String key = HoldKey.of(showId, seatId);
+        String userHoldKey = "hold:user:" + showId + ":" + userId;
 
         // 1. hold 존재 확인
         String owner = holdRedisRepository.getOwner(key);
@@ -78,6 +90,8 @@ public class SeatHoldService {
 
         // 3. key 삭제
         holdRedisRepository.delete(key);
+
+        holdRedisRepository.removeUserHold(userHoldKey, seatId);
 
         return SeatHoldCancelResponse.available(seatId, showId);
     }

--- a/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
@@ -4,7 +4,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import com.demo.seatreservation.domain.Reservation;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
@@ -35,21 +37,30 @@ class SeatHoldControllerTest {
     @BeforeEach
     void setUp() {
         reservationRepository.deleteAll();
+        seatRepository.deleteAll();
 
         // Redis 전체 초기화
         stringRedisTemplate.getConnectionFactory()
                 .getConnection()
                 .flushAll();
+    }
 
-        // 테스트용 Seat 데이터가 없다면 1개 생성해서 테스트가 항상 돌아가게 준비
-        if (seatRepository.count() == 0) {
-            Seat seat = Seat.builder()
-                    .zone("A")
-                    .row(1)
-                    .number(1)
-                    .build();
-            seatRepository.save(seat);
-        }
+    // 공통 좌석 생성
+    private Seat createSeat(int number) {
+        return seatRepository.save(
+                Seat.builder()
+                        .zone("A")
+                        .row(1)
+                        .number(number)
+                        .build()
+        );
+    }
+
+    // 여러 좌석 생성 + 순서 보장
+    private List<Seat> createSeats(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(this::createSeat)
+                .toList();
     }
 
     @Test
@@ -58,13 +69,12 @@ class SeatHoldControllerTest {
         // 1) hold 요청이 성공(200)하는지
         // 2) 응답 JSON이 성공 형태로 내려오는지
         // 3) Redis에 hold 키가 생성되고 TTL이 설정되는지(선점이 실제로 걸렸는지)
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
         long userId = 100L;
 
-        //String key = "hold:" + showId + ":" + seatId;
         String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
 
         mockMvc.perform(
                         post("/api/seats/{seatId}/hold", seatId)
@@ -97,12 +107,9 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // 이미 선점된 좌석을 다른 사용자가 다시 hold하려고 하면
         // 409 Conflict로 막히는지(= SEAT_ALREADY_HELD 케이스)
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
-
-        //String key = "hold:" + showId + ":" + seatId;
-        String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
 
         // 1차 hold (성공)
         mockMvc.perform(
@@ -129,12 +136,11 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // TTL이 만료되면 선점 키가 사라지고
         // 같은 좌석을 다시 hold 할 수 있어야 한다(재선점 가능)
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
 
-        //String key = "hold:" + showId + ":" + seatId;
         String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
 
         // 1차 hold 성공
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -163,7 +169,8 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // DB에 이미 RESERVED 상태의 예약이 있으면
         // hold 요청을 거절해야 한다(= ALREADY_RESERVED 케이스)
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
 
         // 1. DB에 RESERVED 예약 데이터 미리 넣기
@@ -189,7 +196,8 @@ class SeatHoldControllerTest {
     void hold_missingShowId_returns400() throws Exception {
         // 테스트 목적:
         // showId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -201,7 +209,8 @@ class SeatHoldControllerTest {
     void hold_missingUserId_returns400() throws Exception {
         // 테스트 목적:
         // userId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -215,13 +224,12 @@ class SeatHoldControllerTest {
         // 1) 정상적인 hold 취소 요청 시 200 OK 반환
         // 2) Redis hold 키가 삭제되는지 확인
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
         long userId = 100L;
 
-        //String key = "hold:" + showId + ":" + seatId;
         String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
 
         // 먼저 hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -252,7 +260,8 @@ class SeatHoldControllerTest {
         // HOLD를 건 사용자와 다른 userId가 취소하려 하면
         // 403 NOT_HOLD_OWNER가 발생해야 한다
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
 
         //String key = "hold:" + showId + ":" + seatId;
@@ -282,12 +291,11 @@ class SeatHoldControllerTest {
         // HOLD가 이미 만료되었거나 존재하지 않을 때
         // 409 HOLD_EXPIRED가 발생해야 한다
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1);
+        Long seatId = seat.getId();
         long showId = 1L;
 
-        //String key = "hold:" + showId + ":" + seatId;
         String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
 
         // hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -308,5 +316,85 @@ class SeatHoldControllerTest {
                         {"showId": %d, "userId": 100}
                     """.formatted(showId)))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    void hold_exceedsLimit_returns409() throws Exception {
+
+        // 테스트 목적:
+        // 한 사용자가 4개까지는 HOLD 가능하지만
+        // 5번째 HOLD 시도는 409 HOLD_LIMIT_EXCEEDED 발생해야 한다
+
+        long showId = 1L;
+        long userId = 100L;
+
+        List<Seat> seats = createSeats(5);
+
+        // 1~4번 좌석 HOLD 성공
+        for (int i = 0; i < 4; i++) {
+            Long seatId = seats.get(i).getId();
+
+            mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                        {"showId": %d, "userId": %d}
+                        """.formatted(showId, userId)))
+                    .andExpect(status().isOk());
+        }
+
+        // 5번째 HOLD → 실패해야 정상
+        Long seatId5 = seats.get(4).getId();
+
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId5)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"showId": %d, "userId": %d}
+                    """.formatted(showId, userId)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void hold_afterCancel_canHoldAgain() throws Exception {
+
+        // 테스트 목적:
+        // 4개 HOLD 상태에서 하나 cancel 하면
+        // 다시 HOLD가 가능해야 한다
+
+        long showId = 1L;
+        long userId = 100L;
+
+        List<Seat> seats = createSeats(5);
+
+        // 4개 HOLD
+        for (int i = 0; i < 4; i++) {
+            Long seatId = seats.get(i).getId();
+
+            mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                        {"showId": %d, "userId": %d}
+                        """.formatted(showId, userId)))
+                    .andExpect(status().isOk());
+        }
+
+        // 하나 cancel
+        Long cancelSeatId = seats.get(0).getId();
+
+        mockMvc.perform(delete("/api/seats/{seatId}/hold", cancelSeatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"showId": %d, "userId": %d}
+                    """.formatted(showId, userId)))
+                .andExpect(status().isOk());
+
+        // 다시 HOLD → 성공해야 정상
+        Long newSeatId = seats.get(4).getId();
+
+        mockMvc.perform(post("/api/seats/{seatId}/hold", newSeatId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"showId": %d, "userId": %d}
+                    """.formatted(showId, userId)))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
사용자가 동시에 여러 좌석을 무한정 선점하는 것을 방지하기 위해
좌석 HOLD 개수를 최대 4개로 제한하는 기능을 구현하였다.

자세한 설계 구조는 #23 이슈에서 확인

통합 테스트

- 정상 HOLD 4개까지 가능
- 5번째 HOLD 요청 시 실패 확인
- HOLD 취소 시 개수 감소
- 예약 확정 시 HOLD 제거 확인
- 사용자별 HOLD 분리 확인