### PR TITLE
[feat/seat-query-optimization] 좌석 조회 성능 개선 (showId 기준 조회로 변경) #25

### DIFF
--- a/src/main/java/com/demo/seatreservation/domain/Seat.java
+++ b/src/main/java/com/demo/seatreservation/domain/Seat.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @Table(name = "seats",
         uniqueConstraints = @UniqueConstraint(
                 name = "uk_seats_zone_row_number",
-                columnNames = {"zone", "row_num", "seat_number"}
+                columnNames = {"show_id", "zone", "row_num", "seat_number"}
         ))
 public class Seat {
 
@@ -27,6 +27,10 @@ public class Seat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    /* 공연 ID */
+    @Column(nullable = false)
+    private Long showId;
 
     /* 구역 (예: A, B, VIP) */
     @Column(nullable = false, length = 10)
@@ -43,6 +47,7 @@ public class Seat {
     /* 생성 시간 */
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
 
     /**
      * DB insert 직전 자동 실행

--- a/src/main/java/com/demo/seatreservation/repository/SeatRepository.java
+++ b/src/main/java/com/demo/seatreservation/repository/SeatRepository.java
@@ -3,6 +3,7 @@ package com.demo.seatreservation.repository;
 import com.demo.seatreservation.domain.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -13,5 +14,5 @@ import java.util.Optional;
  */
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    Optional<Seat> findByZoneAndRowAndNumber(String zone, Integer row, Integer number);
+    List<Seat> findByShowId(Long showId);
 }

--- a/src/main/java/com/demo/seatreservation/seat/service/SeatQueryFacade.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/SeatQueryFacade.java
@@ -33,7 +33,7 @@ public class SeatQueryFacade {
 
     @Transactional(readOnly = true)
     public List<SeatQueryResponse> getSeats(Long showId) {
-        List<Seat> seats = seatRepository.findAll();
+        List<Seat> seats = seatRepository.findByShowId(showId);
 
         Set<Long> reservedSeatIds = Set.copyOf(
                 reservationRepository.findSeatIdsByShowIdAndStatus(showId, ReservationStatus.RESERVED)

--- a/src/test/java/com/demo/seatreservation/repository/SeatRepositoryTest.java
+++ b/src/test/java/com/demo/seatreservation/repository/SeatRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.demo.seatreservation.repository;
+
+import com.demo.seatreservation.domain.Seat;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+public class SeatRepositoryTest {
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Test
+    void findAll_vs_findByShowId_test() {
+
+        // 테스트 목적:
+        // 1) 여러 공연(showId)의 좌석 데이터가 섞여 있을 때
+        // 2) findAll()과 findByShowId()의 조회 성능 차이를 비교
+        // 3) 불필요한 데이터 조회가 얼마나 비효율적인지 확인
+
+        // findAll(모든 공연 데이터 다 가져옴) vs findByShowId(필요한 공연 데이터만 가져옴)
+
+        // given
+        // showId 1, 2, 3 각각 10,000개 → 총 30,000개
+        for (int i = 1; i <= 10000; i++) {
+            seatRepository.save(
+                    Seat.builder()
+                            .showId(1L)
+                            .zone("A")
+                            .row(i / 100 + 1)
+                            .number(i % 100)
+                            .build()
+            );
+
+            seatRepository.save(
+                    Seat.builder()
+                            .showId(2L)
+                            .zone("A")
+                            .row(i / 100 + 1)
+                            .number(i % 100)
+                            .build()
+            );
+
+            seatRepository.save(
+                    Seat.builder()
+                            .showId(3L)
+                            .zone("A")
+                            .row(i / 100 + 1)
+                            .number(i % 100)
+                            .build()
+            );
+        }
+
+        // when (1) 전체 조회
+        long startAll = System.currentTimeMillis();
+
+        List<Seat> allSeats = seatRepository.findAll();
+
+        long endAll = System.currentTimeMillis();
+
+        // when (2) 특정 show 조회
+        long startFilter = System.currentTimeMillis();
+
+        List<Seat> filteredSeats = seatRepository.findByShowId(1L);
+
+        long endFilter = System.currentTimeMillis();
+
+        // then
+        System.out.println("findAll 조회 개수: " + allSeats.size());
+        System.out.println("findAll 조회 시간: " + (endAll - startAll) + "ms");
+
+        System.out.println("findByShowId 조회 개수: " + filteredSeats.size());
+        System.out.println("findByShowId 조회 시간: " + (endFilter - startFilter) + "ms");
+    }
+}

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
@@ -52,6 +52,7 @@ public class ReservationConfirmControllerTest {
         // 테스트용 좌석 1개 생성
         seatRepository.save(
                 Seat.builder()
+                        .showId(1L)
                         .zone("A")
                         .row(1)
                         .number(1)

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
@@ -34,6 +34,7 @@ class ReservationQueryControllerTest {
         // 좌석 2개 생성 (UNIQUE 충돌 방지)
         seatRepository.save(
                 Seat.builder()
+                        .showId(1L)
                         .zone("A")
                         .row(1)
                         .number(1)
@@ -42,6 +43,7 @@ class ReservationQueryControllerTest {
 
         seatRepository.save(
                 Seat.builder()
+                        .showId(1L)
                         .zone("A")
                         .row(1)
                         .number(2)

--- a/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
@@ -46,9 +46,10 @@ class SeatHoldControllerTest {
     }
 
     // 공통 좌석 생성
-    private Seat createSeat(int number) {
+    private Seat createSeat(Long showId, int number) {
         return seatRepository.save(
                 Seat.builder()
+                        .showId(showId)
                         .zone("A")
                         .row(1)
                         .number(number)
@@ -57,9 +58,9 @@ class SeatHoldControllerTest {
     }
 
     // 여러 좌석 생성 + 순서 보장
-    private List<Seat> createSeats(int count) {
+    private List<Seat> createSeats(Long showId, int count) {
         return IntStream.rangeClosed(1, count)
-                .mapToObj(this::createSeat)
+                .mapToObj(i -> createSeat(showId, i))
                 .toList();
     }
 
@@ -69,7 +70,7 @@ class SeatHoldControllerTest {
         // 1) hold 요청이 성공(200)하는지
         // 2) 응답 JSON이 성공 형태로 내려오는지
         // 3) Redis에 hold 키가 생성되고 TTL이 설정되는지(선점이 실제로 걸렸는지)
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
         long userId = 100L;
@@ -107,7 +108,7 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // 이미 선점된 좌석을 다른 사용자가 다시 hold하려고 하면
         // 409 Conflict로 막히는지(= SEAT_ALREADY_HELD 케이스)
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
@@ -136,7 +137,7 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // TTL이 만료되면 선점 키가 사라지고
         // 같은 좌석을 다시 hold 할 수 있어야 한다(재선점 가능)
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
@@ -169,7 +170,7 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // DB에 이미 RESERVED 상태의 예약이 있으면
         // hold 요청을 거절해야 한다(= ALREADY_RESERVED 케이스)
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
@@ -196,7 +197,7 @@ class SeatHoldControllerTest {
     void hold_missingShowId_returns400() throws Exception {
         // 테스트 목적:
         // showId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -209,7 +210,7 @@ class SeatHoldControllerTest {
     void hold_missingUserId_returns400() throws Exception {
         // 테스트 목적:
         // userId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
@@ -224,7 +225,7 @@ class SeatHoldControllerTest {
         // 1) 정상적인 hold 취소 요청 시 200 OK 반환
         // 2) Redis hold 키가 삭제되는지 확인
 
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
         long userId = 100L;
@@ -260,7 +261,7 @@ class SeatHoldControllerTest {
         // HOLD를 건 사용자와 다른 userId가 취소하려 하면
         // 403 NOT_HOLD_OWNER가 발생해야 한다
 
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
@@ -291,7 +292,7 @@ class SeatHoldControllerTest {
         // HOLD가 이미 만료되었거나 존재하지 않을 때
         // 409 HOLD_EXPIRED가 발생해야 한다
 
-        Seat seat = createSeat(1);
+        Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
@@ -328,7 +329,7 @@ class SeatHoldControllerTest {
         long showId = 1L;
         long userId = 100L;
 
-        List<Seat> seats = createSeats(5);
+        List<Seat> seats = createSeats(1L, 5);
 
         // 1~4번 좌석 HOLD 성공
         for (int i = 0; i < 4; i++) {
@@ -363,7 +364,7 @@ class SeatHoldControllerTest {
         long showId = 1L;
         long userId = 100L;
 
-        List<Seat> seats = createSeats(5);
+        List<Seat> seats = createSeats(1L, 5);
 
         // 4개 HOLD
         for (int i = 0; i < 4; i++) {

--- a/src/test/java/com/demo/seatreservation/seat/controller/SeatQueryControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/SeatQueryControllerTest.java
@@ -52,18 +52,21 @@ class SeatQueryControllerTest {
 
         // 테스트용 좌석 3개 생성
         seatRepository.save(Seat.builder()
+                .showId(1L)
                 .zone("A")
                 .row(1)
                 .number(1)
                 .build());
 
         seatRepository.save(Seat.builder()
+                .showId(1L)
                 .zone("A")
                 .row(1)
                 .number(2)
                 .build());
 
         seatRepository.save(Seat.builder()
+                .showId(1L)
                 .zone("A")
                 .row(1)
                 .number(3)


### PR DESCRIPTION
좌석 조회 시 전체 조회(findAll) 방식에서 발생할 수 있는 성능 문제를 개선하기 위해
showId 기준 조회 방식으로 구조를 변경했다.

또한, 실제 성능 차이를 확인하기 위해 테스트 코드를 추가했다.

자세한 설계는 이슈 #25  확인

## 📊 테스트 결과

| 방식 | 조회 개수 | 시간 |
|------|----------|------|
| findAll | 30,000 | 145ms |
| findByShowId | 10,000 | 77ms |

→ 필요한 데이터만 조회하는 방식이 성능상 유리함을 확인