### PR TITLE
[feat/auth-signup] 회원가입 API 구현 (#30)

### DIFF
--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.demo.seatreservation.auth.controller;
+
+import com.demo.seatreservation.auth.dto.request.SignupRequest;
+import com.demo.seatreservation.auth.dto.response.SignupResponse;
+import com.demo.seatreservation.auth.service.AuthService;
+import com.demo.seatreservation.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+        SignupResponse response = authService.signup(request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/demo/seatreservation/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/request/SignupRequest.java
@@ -1,0 +1,27 @@
+package com.demo.seatreservation.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    private String phone;
+}

--- a/src/main/java/com/demo/seatreservation/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/response/SignupResponse.java
@@ -1,0 +1,13 @@
+package com.demo.seatreservation.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupResponse {
+    private Long userId;
+    private String email;
+    private String name;
+    private String phone;
+}

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.demo.seatreservation.auth.service;
+
+import com.demo.seatreservation.auth.dto.request.SignupRequest;
+import com.demo.seatreservation.auth.dto.response.SignupResponse;
+import com.demo.seatreservation.global.exception.BusinessException;
+import com.demo.seatreservation.global.exception.ErrorCode;
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignupResponse signup(SignupRequest request) {
+
+        // 1. 이메일 중복 체크
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.EMAIL_DUPLICATED);
+        }
+
+        // 2. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 3. User 엔티티 생성
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .name(request.getName())
+                .phone(request.getPhone())
+                .build();
+
+        // 4. DB 저장
+        User savedUser = userRepository.save(user);
+
+        // 5. 응답 DTO 생성 (비밀번호 제외)
+        return SignupResponse.builder()
+                .userId(savedUser.getId())
+                .email(savedUser.getEmail())
+                .name(savedUser.getName())
+                .phone(savedUser.getPhone())
+                .build();
+    }
+}

--- a/src/main/java/com/demo/seatreservation/domain/User.java
+++ b/src/main/java/com/demo/seatreservation/domain/User.java
@@ -36,6 +36,14 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    /* 사용자 이름 */
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    /* 전화번호 */
+    @Column(nullable = false, length = 20)
+    private String phone;
+
     /* 사용자 권한 (USER / ADMIN) */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/demo/seatreservation/repository/UserRepository.java
+++ b/src/main/java/com/demo/seatreservation/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.demo.seatreservation.repository;
+
+import com.demo.seatreservation.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -1,8 +1,10 @@
-package com.demo.seatreservation.security;
+package com.demo.seatreservation.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,5 +18,10 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 );
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthControllerTest.java
@@ -1,0 +1,161 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 데이터 초기화
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void signup_success() throws Exception {
+
+        // 테스트 목적:
+        // 회원가입 요청 시
+        // 정상적으로 회원이 저장되고 응답이 반환되는지 확인
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "password": "12345678",
+                  "name": "홍길동",
+                  "phone": "010-1111-2222"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.userId").exists())
+                .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.phone").value("010-1111-2222"));
+    }
+
+    @Test
+    void signup_duplicatedEmail_returns409() throws Exception {
+
+        // 테스트 목적:
+        // 이미 가입된 이메일로 회원가입 시도하면
+        // 409 EMAIL_DUPLICATED가 발생해야 한다
+
+        userRepository.save(
+                User.builder()
+                        .email("dup@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("기존회원")
+                        .phone("010-0000-0000")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "dup@test.com",
+                  "password": "12345678",
+                  "name": "새회원",
+                  "phone": "010-1111-2222"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("EMAIL_DUPLICATED"));
+    }
+
+    @Test
+    void signup_passwordEncoded_success() throws Exception {
+
+        // 테스트 목적:
+        // 회원가입 시 비밀번호가 평문이 아니라
+        // 암호화되어 저장되는지 확인
+
+        String rawPassword = "12345678";
+
+        String requestBody = """
+                {
+                  "email": "encode@test.com",
+                  "password": "12345678",
+                  "name": "홍길동",
+                  "phone": "010-1111-2222"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk());
+
+        User savedUser = userRepository.findByEmail("encode@test.com")
+                .orElseThrow();
+
+        assert !savedUser.getPassword().equals(rawPassword);
+        assert passwordEncoder.matches(rawPassword, savedUser.getPassword());
+    }
+
+    @Test
+    void signup_invalidRequest_returns400() throws Exception {
+
+        // 테스트 목적:
+        // 회원가입 요청값이 DTO 검증 조건에 맞지 않으면
+        // 400 VALIDATION_ERROR가 발생해야 한다
+
+        String requestBody = """
+                {
+                  "email": "not-email",
+                  "password": "123",
+                  "name": "",
+                  "phone": ""
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+}


### PR DESCRIPTION
- SignupRequest / SignupResponse DTO 추가
- AuthController / AuthService 회원가입 로직 구현
- 이메일 중복 검사 추가
- BCrypt 비밀번호 암호화 저장 적용
- 회원가입 테스트 코드 작성

자세한 설명은 이슈 #30 확인

통합 테스트
- 정상 회원가입
- 이메일 중복
- 비밀번호 암호화 저장
- 요청값 검증 실패