### PR TITLE
[feat/auth-login] 로그인 API 구현 (#33)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -38,6 +42,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 

--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.demo.seatreservation.auth.controller;
 
+import com.demo.seatreservation.auth.dto.request.LoginRequest;
 import com.demo.seatreservation.auth.dto.request.SignupRequest;
+import com.demo.seatreservation.auth.dto.response.LoginResponse;
 import com.demo.seatreservation.auth.dto.response.SignupResponse;
 import com.demo.seatreservation.auth.service.AuthService;
 import com.demo.seatreservation.common.ApiResponse;
@@ -18,6 +20,12 @@ public class AuthController {
     @PostMapping("/signup")
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = authService.signup(request);
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/demo/seatreservation/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.demo.seatreservation.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/demo/seatreservation/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/response/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.demo.seatreservation.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private Long userId;
+    private String email;
+    private String name;
+    private String role;
+    private TokenResponse token;
+}

--- a/src/main/java/com/demo/seatreservation/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/response/TokenResponse.java
@@ -1,0 +1,31 @@
+package com.demo.seatreservation.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 로그인 또는 토큰 재발급 성공 시 클라이언트에 내려주는 토큰 응답 DTO.
+ *
+ * 포함 정보:
+ * - grantType: 토큰 타입 (예: Bearer)
+ * - accessToken: API 인증에 사용하는 Access Token
+ * - refreshToken: Access Token 재발급에 사용하는 Refresh Token
+ * - accessTokenExpiresIn: Access Token 만료 시간(ms)
+ * - refreshTokenExpiresIn: Refresh Token 만료 시간(ms)
+ * - sessionId: 로그인 세션 식별자
+ *
+ * 현재 프로젝트는 다중 기기/다중 세션을 고려하므로
+ * 각 로그인마다 별도의 sessionId를 발급하고,
+ * Refresh Token도 sessionId 단위로 관리한다.
+ */
+
+@Getter
+@Builder
+public class TokenResponse {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+    private Long refreshTokenExpiresIn;
+    private String sessionId;
+}

--- a/src/main/java/com/demo/seatreservation/auth/redis/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/demo/seatreservation/auth/redis/RefreshTokenRedisRepository.java
@@ -1,0 +1,70 @@
+package com.demo.seatreservation.auth.redis;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private String refreshKey(Long userId, String sessionId) {
+        return "refresh:" + userId + ":" + sessionId;
+    }
+
+    private String sessionSetKey(Long userId) {
+        return "refresh:sessions:" + userId;
+    }
+
+    /**
+    * 특정 사용자 세션의 Refresh Token을 저장하고, 세션 목록 Set에도 sessionId를 추가한다.
+    * */
+    public void save(Long userId, String sessionId, String refreshToken, long refreshTokenExpireMs) {
+        redisTemplate.opsForValue().set(
+                refreshKey(userId, sessionId),
+                refreshToken,
+                Duration.ofMillis(refreshTokenExpireMs)
+        );
+
+        redisTemplate.opsForSet().add(sessionSetKey(userId), sessionId);
+    }
+
+    /**
+     * 특정 사용자 세션에 저장된 Refresh Token을 조회한다.
+     * */
+    public String find(Long userId, String sessionId) {
+        return redisTemplate.opsForValue().get(refreshKey(userId, sessionId));
+    }
+
+    /**
+     * 현재 세션의 Refresh Token을 삭제하고,세션 목록 Set에서도 sessionId를 제거한다.
+     * */
+    public void deleteCurrentSession(Long userId, String sessionId) {
+        redisTemplate.delete(refreshKey(userId, sessionId));
+        redisTemplate.opsForSet().remove(sessionSetKey(userId), sessionId);
+    }
+
+    /**
+     * 해당 사용자의 활성 sessionId 목록을 조회한다.
+     * */
+    public Set<String> findSessionIds(Long userId) {
+        Set<String> values = redisTemplate.opsForSet().members(sessionSetKey(userId));
+        return values == null ? Collections.emptySet() : values;
+    }
+
+    /**
+     * 해당 사용자의 모든 세션 Refresh Token을 삭제하고, 세션 목록 Set도 함께 제거한다.
+     * */
+    public void deleteAllSessions(Long userId) {
+        Set<String> sessionIds = findSessionIds(userId);
+        for (String sessionId : sessionIds) {
+            redisTemplate.delete(refreshKey(userId, sessionId));
+        }
+        redisTemplate.delete(sessionSetKey(userId));
+    }
+}

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -1,23 +1,32 @@
 package com.demo.seatreservation.auth.service;
 
+import com.demo.seatreservation.auth.dto.request.LoginRequest;
 import com.demo.seatreservation.auth.dto.request.SignupRequest;
+import com.demo.seatreservation.auth.dto.response.LoginResponse;
 import com.demo.seatreservation.auth.dto.response.SignupResponse;
+import com.demo.seatreservation.auth.dto.response.TokenResponse;
+import com.demo.seatreservation.auth.redis.RefreshTokenRedisRepository;
 import com.demo.seatreservation.global.exception.BusinessException;
 import com.demo.seatreservation.global.exception.ErrorCode;
 import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.repository.UserRepository;
+import com.demo.seatreservation.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
-
 public class AuthService {
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -46,6 +55,62 @@ public class AuthService {
                 .email(savedUser.getEmail())
                 .name(savedUser.getName())
                 .phone(savedUser.getPhone())
+                .build();
+    }
+
+    public LoginResponse login(LoginRequest request) {
+
+        // 1. 이메일로 사용자 조회 (없으면 예외 발생)
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        // 2. 비밀번호 검증 (일치하지 않으면 예외 발생)
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 3. 세션 ID 생성 (중복 방지를 위한 UUID 사용)
+        String sessionId = UUID.randomUUID().toString();
+
+        // 4. Access Token 생성 (사용자 정보 + 세선 ID 포함)
+        String accessToken = jwtTokenProvider.createAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name(),
+                sessionId
+        );
+
+        // 5. Refresh Token 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                user.getId(),
+                sessionId
+        );
+
+        // 6. Refresh Token을 Redis에 저장 (만료 시간 포함)
+        refreshTokenRedisRepository.save(
+                user.getId(),
+                sessionId,
+                refreshToken,
+                jwtTokenProvider.getRefreshTokenExpireMs()
+        );
+
+        // 7. TokenResponse DTO 생성 (토큰 정보 구성)
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpireMs())
+                .refreshTokenExpiresIn(jwtTokenProvider.getRefreshTokenExpireMs())
+                .sessionId(sessionId)
+                .build();
+
+        // 8. LoginResponse 생성 및 반환
+        return LoginResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole().name())
+                .token(tokenResponse)
                 .build();
     }
 }

--- a/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,122 @@
+package com.demo.seatreservation.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 생성 및 검증을 담당하는 유틸 클래스.
+ *
+ * 주요 역할:
+ * - Access Token 생성
+ * - Refresh Token 생성
+ * - 토큰에서 Claims 추출
+ * - 토큰 유효성 검증
+ */
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expire-ms}")
+    private long accessTokenExpireMs;
+
+    @Value("${jwt.refresh-token-expire-ms}")
+    private long refreshTokenExpireMs;
+
+    private Key key;
+
+    /**
+     * application.yml 에서 주입받은 secretKey를 기반으로
+     * JWT 서명/검증에 사용할 Key를 초기화한다.
+     */
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Access Token 생성 **/
+    public String createAccessToken(Long userId, String email, String role, String sessionId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpireMs);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("role", role)
+                .claim("sessionId", sessionId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /** Refresh Token 생성 **/
+    public String createRefreshToken(Long userId, String sessionId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpireMs);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("sessionId", sessionId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /** JWT를 파싱하여 Claims를 반환 **/
+    public Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith((javax.crypto.SecretKey) key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /** JWT 서명, 형식, 만료 여부를 검증 **/
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith((javax.crypto.SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    public String getSessionId(String token) {
+        return parseClaims(token).get("sessionId", String.class);
+    }
+
+    public long getAccessTokenExpireMs() {
+        return accessTokenExpireMs;
+    }
+
+    public long getRefreshTokenExpireMs() {
+        return refreshTokenExpireMs;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+jwt:
+  secret: your-very-long-secret-key-your-very-long-secret-key
+  access-token-expire-ms: 1800000       # 30분
+  refresh-token-expire-ms: 1209600000   # 14일

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
@@ -1,0 +1,351 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.repository.UserRepository;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthLoginControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    StringRedisTemplate redisTemplate;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 데이터 초기화
+        userRepository.deleteAll();
+
+        // Redis 초기화
+        Set<String> keys = redisTemplate.keys("refresh:*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    void login_success() throws Exception {
+
+        // 테스트 목적:
+        // 올바른 이메일/비밀번호로 로그인 시 성공 응답이 반환되는지 확인
+
+        User savedUser = userRepository.save(
+                User.builder()
+                        .email("test@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.userId").value(savedUser.getId()))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"));
+    }
+
+    @Test
+    void login_emailNotFound_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 존재하지 않는 이메일로 로그인 시 401 INVALID_CREDENTIALS가 발생해야 한다
+
+        String requestBody = """
+                {
+                  "email": "no-user@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void login_wrongPassword_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 비밀번호 불일치 시 401 INVALID_CREDENTIALS가 발생해야 한다
+
+        userRepository.save(
+                User.builder()
+                        .email("test@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "password": "wrong-password"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void login_returnsAccessAndRefreshToken() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 accessToken, refreshToken, grantType이 응답에 포함되는지 확인
+
+        userRepository.save(
+                User.builder()
+                        .email("token@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "token@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.token.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.data.token.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.token.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    void login_returnsSessionId() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 sessionId가 응답에 포함되는지 확인
+
+        userRepository.save(
+                User.builder()
+                        .email("session@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "session@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.token.sessionId").isNotEmpty());
+    }
+
+    @Test
+    void login_refreshTokenStoredInRedis_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 Redis의 refresh:{userId}:{sessionId} 키에
+        // refreshToken이 저장되는지 확인
+
+        User savedUser = userRepository.save(
+                User.builder()
+                        .email("redis@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "redis@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        String sessionId = root.path("data").path("token").path("sessionId").asText();
+        String refreshToken = root.path("data").path("token").path("refreshToken").asText();
+
+        String redisKey = "refresh:" + savedUser.getId() + ":" + sessionId;
+        String savedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+
+        assertThat(savedRefreshToken).isEqualTo(refreshToken);
+    }
+
+    @Test
+    void login_sessionIdAddedToSessionSet_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 refresh:sessions:{userId} Set에
+        // sessionId가 추가되는지 확인
+
+        User savedUser = userRepository.save(
+                User.builder()
+                        .email("set@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "set@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        String sessionId = root.path("data").path("token").path("sessionId").asText();
+
+        String sessionSetKey = "refresh:sessions:" + savedUser.getId();
+        Set<String> sessionIds = redisTemplate.opsForSet().members(sessionSetKey);
+
+        assertThat(sessionIds).isNotNull();
+        assertThat(sessionIds).contains(sessionId);
+    }
+
+    @Test
+    void login_multipleSessions_savedSeparately() throws Exception {
+
+        // 테스트 목적:
+        // 같은 유저가 여러 번 로그인해도
+        // 서로 다른 sessionId로 각각 저장되는지 확인
+
+        User savedUser = userRepository.save(
+                User.builder()
+                        .email("multi@test.com")
+                        .password(passwordEncoder.encode("12345678"))
+                        .name("홍길동")
+                        .phone("010-1111-2222")
+                        .build()
+        );
+
+        String requestBody = """
+                {
+                  "email": "multi@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result1 = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MvcResult result2 = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root1 = objectMapper.readTree(result1.getResponse().getContentAsString());
+        JsonNode root2 = objectMapper.readTree(result2.getResponse().getContentAsString());
+
+        String sessionId1 = root1.path("data").path("token").path("sessionId").asText();
+        String sessionId2 = root2.path("data").path("token").path("sessionId").asText();
+
+        assertThat(sessionId1).isNotEqualTo(sessionId2);
+
+        String sessionSetKey = "refresh:sessions:" + savedUser.getId();
+        Set<String> sessionIds = redisTemplate.opsForSet().members(sessionSetKey);
+
+        assertThat(sessionIds).isNotNull();
+        assertThat(sessionIds).contains(sessionId1, sessionId2);
+        assertThat(sessionIds.size()).isEqualTo(2);
+
+        String refreshKey1 = "refresh:" + savedUser.getId() + ":" + sessionId1;
+        String refreshKey2 = "refresh:" + savedUser.getId() + ":" + sessionId2;
+
+        assertThat(redisTemplate.opsForValue().get(refreshKey1)).isNotBlank();
+        assertThat(redisTemplate.opsForValue().get(refreshKey2)).isNotBlank();
+    }
+}

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthSignupControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthSignupControllerTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class AuthControllerTest {
+public class AuthSignupControllerTest {
 
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
- LoginRequest / LoginResponse / TokenResponse DTO 추가
- 로그인 검증 및 Access/Refresh Token 발급 로직 구현
- sessionId 생성 및 Redis Refresh Token 저장 적용
- 로그인 테스트 코드 작성

자세한 설명은 이슈 #33 확인

통합 테스트
- 로그인 성공
- 이메일 없는 경우
- 비밀번호 불일치
- 토큰 응답 확인
- sessionId 응답 확인
- Redis 저장 확인
- 세션 목록 Set 확인
- 다중 로그인 확인