### PR TITLE
[feat/auth-login] 로그인 API 구현 (#33)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.demo.seatreservation.auth.controller;
 
+import com.demo.seatreservation.auth.dto.request.LoginRequest;
 import com.demo.seatreservation.auth.dto.request.SignupRequest;
-import com.demo.seatreservation.auth.dto.response.SignupResponse;
+import com.demo.seatreservation.auth.dto.response.*;
 import com.demo.seatreservation.auth.service.AuthService;
+import com.demo.seatreservation.auth.util.RefreshTokenCookieProvider;
 import com.demo.seatreservation.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,10 +18,32 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final RefreshTokenCookieProvider refreshTokenCookieProvider;
 
     @PostMapping("/signup")
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = authService.signup(request);
         return ApiResponse.ok(response);
+    }
+
+    /**
+     * 로그인
+     *
+     * - access token -> body
+     * - refresh token -> cookie
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        AuthService.LoginWithRefreshResult result = authService.loginWithRefresh(request);
+
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        refreshTokenCookieProvider.createCookie(result.refreshToken()).toString()
+                )
+                .body(ApiResponse.ok(result.loginResponse()));
+
     }
 }

--- a/src/main/java/com/demo/seatreservation/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/request/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.demo.seatreservation.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/demo/seatreservation/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/response/LoginResponse.java
@@ -1,0 +1,26 @@
+package com.demo.seatreservation.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 로그인 응답 DTO
+ *
+ * 웹 기준 응답
+ * - access token 은 body 로 반환
+ * - refresh token 은 cookie 로 반환
+ */
+@Getter
+@Builder
+public class LoginResponse {
+
+    private Long userId;
+    private String email;
+    private String name;
+    private String role;
+
+    private String grantType;
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+    private String sessionId;
+}

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -1,23 +1,31 @@
 package com.demo.seatreservation.auth.service;
 
+import com.demo.seatreservation.auth.dto.request.LoginRequest;
 import com.demo.seatreservation.auth.dto.request.SignupRequest;
-import com.demo.seatreservation.auth.dto.response.SignupResponse;
+import com.demo.seatreservation.auth.dto.response.*;
 import com.demo.seatreservation.global.exception.BusinessException;
 import com.demo.seatreservation.global.exception.ErrorCode;
 import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.repository.UserRepository;
+import com.demo.seatreservation.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
-
 public class AuthService {
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final StringRedisTemplate stringRedisTemplate;
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -47,5 +55,126 @@ public class AuthService {
                 .name(savedUser.getName())
                 .phone(savedUser.getPhone())
                 .build();
+    }
+
+    /**
+     * 로그인
+     *
+     * - 이메일/비밀번호 검증
+     * - sessionId 생성
+     * - access / refresh token 생성
+     * - Redis 에 refresh token 저장
+     * - 웹 응답용 LoginResponse 반환
+     */
+    public LoginResponse login(LoginRequest request) {
+        // 1. 이메일로 사용자 조회
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 3. 세션 식별용 sessionId 생성
+        String sessionId = UUID.randomUUID().toString();
+
+        // 4. access / refresh token 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
+
+        // 5. Redis 에 refresh token 저장
+        saveRefreshToken(user.getId(), sessionId, refreshToken);
+
+        // 6. access token 응답 DTO 반환
+        return LoginResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole().name())
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpiration())
+                .sessionId(sessionId)
+                .build();
+    }
+
+    /**
+     * 웹 응답에서는 refresh token 을 body 로 내리지 않지만,
+     * 쿠키에 담기 위해 controller 에서 별도로 꺼내 쓸 수 있도록 제공
+     */
+    public String createRefreshToken(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String sessionId = UUID.randomUUID().toString();
+        return jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
+    }
+
+    /**
+     * 로그인 1회에 대해 access / refresh / sessionId가 반드시 동일 세트여야 하므로
+     * controller 에서 refresh token을 따로 다시 만들지 않게
+     * 내부 전용 메서드로 한 번에 생성/저장한다.
+     */
+    public LoginWithRefreshResult loginWithRefresh(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String sessionId = UUID.randomUUID().toString();
+        String accessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
+
+        saveRefreshToken(user.getId(), sessionId, refreshToken);
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole().name())
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpiration())
+                .sessionId(sessionId)
+                .build();
+
+        return new LoginWithRefreshResult(loginResponse, refreshToken);
+    }
+
+    /**
+     * Redis 저장 규칙
+     *
+     * refresh:{userId}:{sessionId} = refreshToken
+     * refresh:sessions:{userId} = sessionId Set
+     */
+    private void saveRefreshToken(Long userId, String sessionId, String refreshToken) {
+        String refreshKey = "refresh:" + userId + ":" + sessionId;
+        String sessionSetKey = "refresh:sessions:" + userId;
+
+        long refreshExpiration = jwtTokenProvider.getRefreshTokenExpiration();
+
+        // refresh token 저장
+        stringRedisTemplate.opsForValue()
+                .set(refreshKey, refreshToken, Duration.ofMillis(refreshExpiration));
+
+        // 세션 목록 Set 에 sessionId 추가
+        stringRedisTemplate.opsForSet()
+                .add(sessionSetKey, sessionId);
+
+        // 세션 목록 Set 에도 만료 시간 설정
+        stringRedisTemplate.expire(sessionSetKey, Duration.ofMillis(refreshExpiration));
+    }
+
+    public record LoginWithRefreshResult(
+            LoginResponse loginResponse,
+            String refreshToken
+    ) {
     }
 }

--- a/src/main/java/com/demo/seatreservation/auth/util/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/demo/seatreservation/auth/util/RefreshTokenCookieProvider.java
@@ -1,0 +1,36 @@
+package com.demo.seatreservation.auth.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * 웹용 Refresh Token 쿠키 생성/삭제 유틸
+ */
+@Component
+public class RefreshTokenCookieProvider {
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    // Refresh Token 쿠키 생성
+    public ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/api/auth/refresh")
+                .maxAge(refreshTokenExpiration / 1000)
+                .build();
+    }
+
+    // Refresh Token 쿠키 삭제
+    public ResponseCookie deleteCookie() {
+        return ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/api/auth/refresh")
+                .maxAge(0)
+                .build();
+    }
+}

--- a/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,132 @@
+package com.demo.seatreservation.security.jwt;
+
+import com.demo.seatreservation.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 생성/파싱/검증 담당 클래스
+ */
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey key;
+
+    // secret 문자열을 JWT 서명용 SecretKey 로 변환
+    @PostConstruct
+    protected void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Access Token 생성
+    public String generateAccessToken(User user, String sessionId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("userId", user.getId())
+                .claim("email", user.getEmail())
+                .claim("role", user.getRole().name())
+                .claim("sessionId", sessionId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String generateRefreshToken(Long userId, String sessionId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("userId", userId)
+                .claim("sessionId", sessionId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰에서 Claims 추출
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    // 토큰 서명/형식 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 토큰 만료 여부 확인
+    public boolean isExpired(String token) {
+        try {
+            return getClaims(token).getExpiration().before(new Date());
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    public Long getUserId(String token) {
+        Object value = getClaims(token).get("userId");
+        if (value instanceof Integer integerValue) {
+            return integerValue.longValue();
+        }
+        if (value instanceof Long longValue) {
+            return longValue;
+        }
+        return Long.valueOf(String.valueOf(value));
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public String getSessionId(String token) {
+        return getClaims(token).get("sessionId", String.class);
+    }
+
+    public long getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+jwt:
+  secret: your-very-long-secret-key-your-very-long-secret-key-1234567890
+  access-token-expiration: 1800000      # 30분
+  refresh-token-expiration: 1209600000  # 14일

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
@@ -1,0 +1,371 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.domain.enums.Role;
+import com.demo.seatreservation.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Set;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthLoginControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 데이터 초기화
+        userRepository.deleteAll();
+
+        Set<String> refreshKeys = stringRedisTemplate.keys("refresh:*");
+        if (refreshKeys != null && !refreshKeys.isEmpty()) {
+            stringRedisTemplate.delete(refreshKeys);
+        }
+    }
+
+    private User saveUser(String email, String rawPassword, String name, String phone) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(rawPassword))
+                        .name(name)
+                        .phone(phone)
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    @Test
+    void login_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 요청 시
+        // access token, sessionId가 정상 응답되고 쿠키가 발급되는지 확인
+
+        User savedUser = saveUser("test@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.userId").value(savedUser.getId()))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andExpect(jsonPath("$.data.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.accessTokenExpiresIn").isNumber())
+                .andExpect(jsonPath("$.data.sessionId").isNotEmpty());
+    }
+
+    @Test
+    void login_userNotFound_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 존재하지 않는 이메일로 로그인 시도하면
+        // 401 INVALID_CREDENTIALS가 발생해야 한다
+
+        String requestBody = """
+                {
+                  "email": "nouser@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void login_wrongPassword_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 비밀번호가 일치하지 않으면
+        // 401 INVALID_CREDENTIALS가 발생해야 한다
+
+        saveUser("test@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "password": "wrong-password"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void login_invalidRequest_returns400() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 요청값이 DTO 검증 조건에 맞지 않으면
+        // 400 VALIDATION_ERROR가 발생해야 한다
+
+        String requestBody = """
+                {
+                  "email": "not-email",
+                  "password": ""
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void login_accessTokenAndSessionId_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 access token과 sessionId가
+        // 정상적으로 응답되는지 확인
+
+        saveUser("token@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "token@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.sessionId").isNotEmpty());
+    }
+
+    @Test
+    void login_refreshTokenSavedInRedis_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 Redis에
+        // refresh:{userId}:{sessionId} = refreshToken 이 저장되는지 확인
+
+        User savedUser = saveUser("redis@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "redis@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JsonNode root = objectMapper.readTree(responseBody);
+
+        String sessionId = root.get("data").get("sessionId").asText();
+        String refreshKey = "refresh:" + savedUser.getId() + ":" + sessionId;
+
+        String setCookie = result.getResponse().getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        assertThat(setCookie).contains("refreshToken=");
+
+        String refreshToken = extractRefreshTokenFromCookie(setCookie);
+        String savedRefreshToken = stringRedisTemplate.opsForValue().get(refreshKey);
+
+        assertThat(savedRefreshToken).isEqualTo(refreshToken);
+    }
+
+    @Test
+    void login_sessionIdAddedToSet_success() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 refresh:sessions:{userId} Set에
+        // sessionId가 추가되는지 확인
+
+        User savedUser = saveUser("session@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "session@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JsonNode root = objectMapper.readTree(responseBody);
+
+        String sessionId = root.get("data").get("sessionId").asText();
+        String sessionSetKey = "refresh:sessions:" + savedUser.getId();
+
+        Boolean isMember = stringRedisTemplate.opsForSet().isMember(sessionSetKey, sessionId);
+
+        assertThat(isMember).isTrue();
+    }
+
+    @Test
+    void login_sameUserMultipleTimes_differentSessionId() throws Exception {
+
+        // 테스트 목적:
+        // 같은 유저가 여러 번 로그인해도
+        // 서로 다른 sessionId가 각각 발급되고 저장되는지 확인
+
+        User savedUser = saveUser("multi@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "multi@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        MvcResult result1 = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MvcResult result2 = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody1 = result1.getResponse().getContentAsString();
+        String responseBody2 = result2.getResponse().getContentAsString();
+
+        JsonNode root1 = objectMapper.readTree(responseBody1);
+        JsonNode root2 = objectMapper.readTree(responseBody2);
+
+        String sessionId1 = root1.get("data").get("sessionId").asText();
+        String sessionId2 = root2.get("data").get("sessionId").asText();
+
+        assertThat(sessionId1).isNotEqualTo(sessionId2);
+
+        String refreshKey1 = "refresh:" + savedUser.getId() + ":" + sessionId1;
+        String refreshKey2 = "refresh:" + savedUser.getId() + ":" + sessionId2;
+
+        assertThat(stringRedisTemplate.hasKey(refreshKey1)).isTrue();
+        assertThat(stringRedisTemplate.hasKey(refreshKey2)).isTrue();
+    }
+
+    @Test
+    void login_refreshTokenInCookieOnly() throws Exception {
+
+        // 테스트 목적:
+        // 로그인 성공 시 refresh token은 body가 아니라
+        // Set-Cookie 헤더로 내려가야 한다
+
+        saveUser("cookie@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        String requestBody = """
+                {
+                  "email": "cookie@test.com",
+                  "password": "12345678"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.sessionId").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+    }
+
+    private String extractRefreshTokenFromCookie(String setCookieHeader) {
+        String[] parts = setCookieHeader.split(";");
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("refreshToken=")) {
+                return trimmed.substring("refreshToken=".length());
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthSignupControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthSignupControllerTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class AuthControllerTest {
+public class AuthSignupControllerTest {
 
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
- LoginRequest / LoginResponse DTO 추가
- AuthController / AuthService 로그인 로직 구현
- 이메일/비밀번호 검증 추가
- Access Token / Refresh Token 발급 구현
- Refresh Token 쿠키 저장 적용(HttpOnly, Secure, SameSite, Path 제한)
- Redis Refresh Token 저장 및 sessionId Set 관리 추가
- 로그인 테스트 코드 작성

자세한 설명은 이슈 #33 확인