### PR TITLE
[feat/auth-login] 로그인, opaque refresh token, refresh 재발급 구현 (#33)

### DIFF
--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.demo.seatreservation.auth.dto.response.*;
 import com.demo.seatreservation.auth.service.AuthService;
 import com.demo.seatreservation.auth.util.RefreshTokenCookieProvider;
 import com.demo.seatreservation.common.ApiResponse;
+import com.demo.seatreservation.global.exception.BusinessException;
+import com.demo.seatreservation.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -45,5 +47,30 @@ public class AuthController {
                 )
                 .body(ApiResponse.ok(result.loginResponse()));
 
+    }
+
+    /**
+     * Access Token 재발급 (Refresh Token Rotation)
+     *
+     * - refresh token -> HttpOnly 쿠키에서 추출
+     * - 새 access token -> body
+     * - 새 refresh token -> Set-Cookie
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<RefreshResponse>> refresh(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    ) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        AuthService.RefreshWithNewTokensResult result = authService.refresh(refreshToken);
+
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        refreshTokenCookieProvider.createCookie(result.newRefreshToken()).toString()
+                )
+                .body(ApiResponse.ok(result.refreshResponse()));
     }
 }

--- a/src/main/java/com/demo/seatreservation/auth/dto/response/RefreshResponse.java
+++ b/src/main/java/com/demo/seatreservation/auth/dto/response/RefreshResponse.java
@@ -1,0 +1,13 @@
+package com.demo.seatreservation.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RefreshResponse {
+    private String grantType;
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+    private String sessionId;
+}

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -9,13 +9,17 @@ import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.Base64;
 import java.util.UUID;
+
+import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,11 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final StringRedisTemplate stringRedisTemplate;
+
+    @Value("${jwt.refresh-token-expiration-ms}")
+    private long refreshTokenExpirationMs;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -59,67 +68,14 @@ public class AuthService {
 
     /**
      * 로그인
-     *
-     * - 이메일/비밀번호 검증
-     * - sessionId 생성
-     * - access / refresh token 생성
-     * - Redis 에 refresh token 저장
-     * - 웹 응답용 LoginResponse 반환
+     * - access token + refresh token을 한 번에 발급
+     * - refresh token은 body가 아니라 cookie로 내려주기 위해
+     *   내부적으로 loginWithRefresh()를 재사용
      */
     public LoginResponse login(LoginRequest request) {
-        // 1. 이메일로 사용자 조회
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
-
-        // 2. 비밀번호 검증
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
-        }
-
-        // 3. 세션 식별용 sessionId 생성
-        String sessionId = UUID.randomUUID().toString();
-
-        // 4. access / refresh token 생성
-        String accessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
-
-        // 5. Redis 에 refresh token 저장
-        saveRefreshToken(user.getId(), sessionId, refreshToken);
-
-        // 6. access token 응답 DTO 반환
-        return LoginResponse.builder()
-                .userId(user.getId())
-                .email(user.getEmail())
-                .name(user.getName())
-                .role(user.getRole().name())
-                .grantType("Bearer")
-                .accessToken(accessToken)
-                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpiration())
-                .sessionId(sessionId)
-                .build();
+        return loginWithRefresh(request).loginResponse();
     }
 
-    /**
-     * 웹 응답에서는 refresh token 을 body 로 내리지 않지만,
-     * 쿠키에 담기 위해 controller 에서 별도로 꺼내 쓸 수 있도록 제공
-     */
-    public String createRefreshToken(LoginRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
-
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
-        }
-
-        String sessionId = UUID.randomUUID().toString();
-        return jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
-    }
-
-    /**
-     * 로그인 1회에 대해 access / refresh / sessionId가 반드시 동일 세트여야 하므로
-     * controller 에서 refresh token을 따로 다시 만들지 않게
-     * 내부 전용 메서드로 한 번에 생성/저장한다.
-     */
     public LoginWithRefreshResult loginWithRefresh(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
@@ -128,10 +84,16 @@ public class AuthService {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
 
+        // 세션 단위로 refresh token을 구분하기 위한 값
         String sessionId = UUID.randomUUID().toString();
-        String accessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), sessionId);
 
+        // access token은 JWT로 발급
+        String accessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
+
+        // refresh token은 JWT가 아닌 랜덤 문자열(opaque token)로 발급
+        String refreshToken = generateOpaqueRefreshToken();
+
+        // Redis에 refresh token 저장
         saveRefreshToken(user.getId(), sessionId, refreshToken);
 
         LoginResponse loginResponse = LoginResponse.builder()
@@ -149,32 +111,164 @@ public class AuthService {
     }
 
     /**
+     * opaque refresh token 생성
+     * - JWT 아님
+     * - 충분히 긴 랜덤 문자열
+     */
+    private String generateOpaqueRefreshToken() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /**
      * Redis 저장 규칙
      *
      * refresh:{userId}:{sessionId} = refreshToken
+     * refresh:token:{refreshToken} = {userId}:{sessionId}
      * refresh:sessions:{userId} = sessionId Set
+     *
+     * refresh token 만료 시간과 세션 목록 만료 시간을 동일하게 맞춘다.
      */
     private void saveRefreshToken(Long userId, String sessionId, String refreshToken) {
         String refreshKey = "refresh:" + userId + ":" + sessionId;
+        String refreshLookupKey = "refresh:token:" + refreshToken;
         String sessionSetKey = "refresh:sessions:" + userId;
 
-        long refreshExpiration = jwtTokenProvider.getRefreshTokenExpiration();
+        Duration ttl = Duration.ofMillis(refreshTokenExpirationMs);
 
-        // refresh token 저장
+        // 세션별 refresh token 저장
         stringRedisTemplate.opsForValue()
-                .set(refreshKey, refreshToken, Duration.ofMillis(refreshExpiration));
+                .set(refreshKey, refreshToken, ttl);
 
-        // 세션 목록 Set 에 sessionId 추가
+        // refresh token 문자열로 userId/sessionId를 찾기 위한 역조회 키 저장
+        stringRedisTemplate.opsForValue()
+                .set(refreshLookupKey, userId + ":" + sessionId, ttl);
+
+        // 해당 사용자의 세션 목록에 sessionId 추가
         stringRedisTemplate.opsForSet()
                 .add(sessionSetKey, sessionId);
 
-        // 세션 목록 Set 에도 만료 시간 설정
-        stringRedisTemplate.expire(sessionSetKey, Duration.ofMillis(refreshExpiration));
+        // 세션 목록도 만료 시간 설정
+        stringRedisTemplate.expire(sessionSetKey, ttl);
     }
 
+    /**
+     * Refresh Token 재발급
+     * - 쿠키로 들어온 opaque refresh token을 Redis에서 역조회
+     * - userId / sessionId 확인
+     * - Redis에 저장된 값과 비교
+     * - 성공 시 새 access token + 새 refresh token 발급(rotation)
+     */
+    public RefreshWithNewTokensResult refresh(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // refresh token 문자열로 userId/sessionId 찾기
+        String refreshLookupKey = "refresh:token:" + refreshToken;
+        String refreshMetadata = stringRedisTemplate.opsForValue().get(refreshLookupKey);
+
+        // Redis에 없으면 유효하지 않은 토큰으로 처리
+        if (refreshMetadata == null || refreshMetadata.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // refreshMetadata 형식: "userId:sessionId"
+        RefreshTokenContext context = parseRefreshMetadata(refreshMetadata);
+        Long userId = context.userId();
+        String sessionId = context.sessionId();
+
+        String refreshKey = "refresh:" + userId + ":" + sessionId;
+        String sessionSetKey = "refresh:sessions:" + userId;
+
+        // Redis에 저장된 실제 refresh token과 비교
+        String storedToken = stringRedisTemplate.opsForValue().get(refreshKey);
+
+        // 값이 다르면 탈취 또는 위조 가능성으로 처리
+        if (storedToken == null || !storedToken.equals(refreshToken)) {
+            deleteRefreshSession(refreshKey, refreshLookupKey, sessionSetKey, sessionId);
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
+        String newRefreshToken = generateOpaqueRefreshToken();
+
+        // 기존 토큰 삭제 후 새 토큰 저장 (rotation)
+        stringRedisTemplate.delete(refreshLookupKey);
+        saveRefreshToken(userId, sessionId, newRefreshToken);
+
+        // access token만 응답 body로 내려주기 위한 DTO
+        RefreshResponse refreshResponse = RefreshResponse.builder()
+                .grantType("Bearer")
+                .accessToken(newAccessToken)
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpiration())
+                .sessionId(sessionId)
+                .build();
+
+        return new RefreshWithNewTokensResult(refreshResponse, newRefreshToken);
+    }
+
+    /**
+     * Redis에 저장된 "userId:sessionId" 문자열을 분리해서 객체로 변환
+     */
+    private RefreshTokenContext parseRefreshMetadata(String metadata) {
+        String[] parts = metadata.split(":", 2);
+        if (parts.length != 2) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        try {
+            Long userId = Long.valueOf(parts[0]);
+            String sessionId = parts[1];
+            return new RefreshTokenContext(userId, sessionId);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * refresh token 검증 실패 시
+     * 해당 세션의 refresh 관련 데이터 삭제
+     */
+    private void deleteRefreshSession(
+            String refreshKey,
+            String refreshLookupKey,
+            String sessionSetKey,
+            String sessionId
+    ) {
+        stringRedisTemplate.delete(refreshKey);
+        stringRedisTemplate.delete(refreshLookupKey);
+        stringRedisTemplate.opsForSet().remove(sessionSetKey, sessionId);
+    }
+
+    /**
+     * 로그인 결과와 refresh token을 함께 반환하기 위한 내부 record
+     */
     public record LoginWithRefreshResult(
             LoginResponse loginResponse,
             String refreshToken
+    ) {
+    }
+
+    /**
+     * refresh 결과와 새 refresh token을 함께 반환하기 위한 내부 record
+     */
+    public record RefreshWithNewTokensResult(
+            RefreshResponse refreshResponse,
+            String newRefreshToken
+    ) {
+    }
+
+    /**
+     * refresh token 역조회 결과를 담는 내부 record
+     */
+    private record RefreshTokenContext(
+            Long userId,
+            String sessionId
     ) {
     }
 }

--- a/src/main/java/com/demo/seatreservation/auth/util/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/demo/seatreservation/auth/util/RefreshTokenCookieProvider.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RefreshTokenCookieProvider {
-    @Value("${jwt.refresh-token-expiration}")
-    private long refreshTokenExpiration;
+    @Value("${jwt.refresh-token-expiration-ms}")
+    private long refreshTokenExpirationMs;
 
     // Refresh Token 쿠키 생성
     public ResponseCookie createCookie(String refreshToken) {
@@ -19,7 +19,7 @@ public class RefreshTokenCookieProvider {
                 .secure(true)
                 .sameSite("Strict")
                 .path("/api/auth/refresh")
-                .maxAge(refreshTokenExpiration / 1000)
+                .maxAge(refreshTokenExpirationMs / 1000)
                 .build();
     }
 

--- a/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
+++ b/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
@@ -10,7 +10,6 @@ public enum ErrorCode {
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 실패 (Access Token 없음/만료/유효하지 않음)"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token 위조 또는 불일치"),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token 만료"),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일/비밀번호 불일치"),
 
     // 403

--- a/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -14,9 +14,21 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(
+                        org.springframework.security.config.http.SessionCreationPolicy.STATELESS
+                ))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers(
+                                "/api/auth/signup",
+                                "/api/auth/login",
+                                "/api/auth/refresh",
+                                "/api/shows/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
                 );
+
         return http.build();
     }
 

--- a/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/demo/seatreservation/security/jwt/JwtTokenProvider.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 /**
  * JWT 생성/파싱/검증 담당 클래스
+ * - Access Token only
+ * - Refresh Token은 opaque token 사용
  */
 @Component
 public class JwtTokenProvider {
@@ -22,11 +24,9 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    @Value("${jwt.access-token-expiration}")
+    @Value("${jwt.access-token-expiration-ms}")
     private long accessTokenExpiration;
 
-    @Value("${jwt.refresh-token-expiration}")
-    private long refreshTokenExpiration;
 
     private SecretKey key;
 
@@ -46,21 +46,6 @@ public class JwtTokenProvider {
                 .claim("userId", user.getId())
                 .claim("email", user.getEmail())
                 .claim("role", user.getRole().name())
-                .claim("sessionId", sessionId)
-                .issuedAt(now)
-                .expiration(expiry)
-                .signWith(key)
-                .compact();
-    }
-
-    // Refresh Token 생성
-    public String generateRefreshToken(Long userId, String sessionId) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
-
-        return Jwts.builder()
-                .subject(String.valueOf(userId))
-                .claim("userId", userId)
                 .claim("sessionId", sessionId)
                 .issuedAt(now)
                 .expiration(expiry)
@@ -124,9 +109,5 @@ public class JwtTokenProvider {
 
     public long getAccessTokenExpiration() {
         return accessTokenExpiration;
-    }
-
-    public long getRefreshTokenExpiration() {
-        return refreshTokenExpiration;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,5 +23,5 @@ spring:
 
 jwt:
   secret: your-very-long-secret-key-your-very-long-secret-key-1234567890
-  access-token-expiration: 1800000      # 30분
-  refresh-token-expiration: 1209600000  # 14일
+  access-token-expiration-ms: 1800000      # 30분
+  refresh-token-expiration-ms: 604800000  # 14일

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthLoginControllerTest.java
@@ -209,7 +209,7 @@ public class AuthLoginControllerTest {
 
         // 테스트 목적:
         // 로그인 성공 시 Redis에
-        // refresh:{userId}:{sessionId} = refreshToken 이 저장되는지 확인
+        // refresh:{userId}:{sessionId} = opaque refreshToken 이 저장되는지 확인
 
         User savedUser = saveUser("redis@test.com", "12345678", "홍길동", "010-1111-2222");
 
@@ -333,7 +333,7 @@ public class AuthLoginControllerTest {
     void login_refreshTokenInCookieOnly() throws Exception {
 
         // 테스트 목적:
-        // 로그인 성공 시 refresh token은 body가 아니라
+        // 로그인 성공 시 opaque refresh token은 body가 아니라
         // Set-Cookie 헤더로 내려가야 한다
 
         saveUser("cookie@test.com", "12345678", "홍길동", "010-1111-2222");

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthRefreshControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthRefreshControllerTest.java
@@ -1,0 +1,287 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.domain.enums.Role;
+import com.demo.seatreservation.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Set;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthRefreshControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        Set<String> refreshKeys = stringRedisTemplate.keys("refresh:*");
+        if (refreshKeys != null && !refreshKeys.isEmpty()) {
+            stringRedisTemplate.delete(refreshKeys);
+        }
+    }
+
+    private User saveUser(String email, String rawPassword, String name, String phone) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(rawPassword))
+                        .name(name)
+                        .phone(phone)
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private LoginResult loginAndGetResult(String email, String password) throws Exception {
+        String requestBody = """
+                {
+                  "email": "%s",
+                  "password": "%s"
+                }
+                """.formatted(email, password);
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.sessionId").isNotEmpty())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        String sessionId = root.get("data").get("sessionId").asText();
+        String accessToken = root.get("data").get("accessToken").asText();
+        String refreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
+
+        return new LoginResult(sessionId, accessToken, refreshToken);
+    }
+
+    @Test
+    void refresh_noCookie_returns401() throws Exception {
+        // 테스트 목적:
+        // refresh cookie가 없으면 401 UNAUTHORIZED가 반환되어야 한다
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void refresh_success_reissuesAccessAndRefresh() throws Exception {
+        // 테스트 목적:
+        // refresh 성공 시 access token과 refresh token이
+        // 모두 새로 발급되는지 확인
+
+        User savedUser = saveUser("refresh@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult loginResult = loginAndGetResult("refresh@test.com", "12345678");
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.accessTokenExpiresIn").isNumber())
+                .andExpect(jsonPath("$.data.sessionId").value(loginResult.sessionId()))
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        String newAccessToken = root.get("data").get("accessToken").asText();
+        String newRefreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
+
+        assertThat(newAccessToken).isNotBlank();
+        assertThat(newRefreshToken).isNotBlank();
+        assertThat(newRefreshToken).isNotEqualTo(loginResult.refreshToken());
+
+        String refreshKey = "refresh:" + savedUser.getId() + ":" + loginResult.sessionId();
+        String storedRefreshToken = stringRedisTemplate.opsForValue().get(refreshKey);
+        assertThat(storedRefreshToken).isEqualTo(newRefreshToken);
+
+        String lookupKey = "refresh:token:" + newRefreshToken;
+        String metadata = stringRedisTemplate.opsForValue().get(lookupKey);
+        assertThat(metadata).isEqualTo(savedUser.getId() + ":" + loginResult.sessionId());
+    }
+
+    @Test
+    void refresh_oldRefreshTokenReuse_returns401() throws Exception {
+        // 테스트 목적:
+        // refresh rotation 후 이전 refresh token을 다시 쓰면
+        // 401 INVALID_REFRESH_TOKEN이 발생해야 한다
+
+        User savedUser = saveUser("reuse@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult loginResult = loginAndGetResult("reuse@test.com", "12345678");
+
+        MvcResult firstRefresh = mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String newRefreshToken = extractRefreshTokenFromCookie(firstRefresh.getResponse().getHeader("Set-Cookie"));
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+
+        String refreshKey = "refresh:" + savedUser.getId() + ":" + loginResult.sessionId();
+        assertThat(stringRedisTemplate.opsForValue().get(refreshKey)).isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    void refresh_redisMismatch_returns401() throws Exception {
+        // 테스트 목적:
+        // Redis에 저장된 refresh token 값과
+        // 쿠키 값이 다르면 401 INVALID_REFRESH_TOKEN이 발생해야 한다
+
+        User savedUser = saveUser("mismatch@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult loginResult = loginAndGetResult("mismatch@test.com", "12345678");
+
+        String refreshKey = "refresh:" + savedUser.getId() + ":" + loginResult.sessionId();
+        stringRedisTemplate.opsForValue().set(refreshKey, "tampered-refresh-token");
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+
+        String sessionSetKey = "refresh:sessions:" + savedUser.getId();
+        Boolean isMember = stringRedisTemplate.opsForSet().isMember(sessionSetKey, loginResult.sessionId());
+        assertThat(isMember).isFalse();
+    }
+
+    @Test
+    void refresh_multipleDevices_independentSuccess() throws Exception {
+        // 테스트 목적:
+        // 같은 유저가 여러 기기에서 로그인한 경우
+        // 각 refresh token이 독립적으로 동작해야 한다
+
+        User savedUser = saveUser("device@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        LoginResult deviceA = loginAndGetResult("device@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("device@test.com", "12345678");
+
+        assertThat(deviceA.sessionId()).isNotEqualTo(deviceB.sessionId());
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceA.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(deviceA.sessionId()));
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceB.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(deviceB.sessionId()));
+
+        String refreshKeyA = "refresh:" + savedUser.getId() + ":" + deviceA.sessionId();
+        String refreshKeyB = "refresh:" + savedUser.getId() + ":" + deviceB.sessionId();
+
+        assertThat(stringRedisTemplate.hasKey(refreshKeyA)).isTrue();
+        assertThat(stringRedisTemplate.hasKey(refreshKeyB)).isTrue();
+    }
+
+    @Test
+    void refresh_cookieReissued_success() throws Exception {
+        // 테스트 목적:
+        // refresh 성공 시 새 refresh token이
+        // Set-Cookie로 다시 내려가는지 확인
+
+        saveUser("cookie@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult loginResult = loginAndGetResult("cookie@test.com", "12345678");
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+                .andExpect(header().string("Set-Cookie", containsString("Path=/api/auth/refresh")))
+                .andReturn();
+
+        String newRefreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
+        assertThat(newRefreshToken).isNotBlank();
+        assertThat(newRefreshToken).isNotEqualTo(loginResult.refreshToken());
+    }
+
+    private String extractRefreshTokenFromCookie(String setCookieHeader) {
+        String[] parts = setCookieHeader.split(";");
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("refreshToken=")) {
+                return trimmed.substring("refreshToken=".length());
+            }
+        }
+        return null;
+    }
+
+    private record LoginResult(
+            String sessionId,
+            String accessToken,
+            String refreshToken
+    ) {
+    }
+}


### PR DESCRIPTION
## 변경 내용
- Refresh Token 저장 방식을 JWT에서 opaque token으로 변경
- Refresh Token을 Redis에 저장하고 역조회 가능한 구조로 수정
- Refresh 재발급 API 구현
- Refresh Rotation 적용
- refresh token 재사용 방지 처리 추가
- refresh token을 HttpOnly Cookie로 내려주도록 구현

자세한 내용은 이슈 #33 확인

## Test
- 로그인 성공 시 access token은 body로 반환
- refresh token은 cookie로 반환
- refresh 성공 시 access token / refresh token 모두 재발급
- 이전 refresh token 재사용 시 실패 확인
- Redis 저장값과 요청값 불일치 시 실패 확인