### PR TITLE
[feat/auth-logout] 현재 세션 로그아웃 및 refresh 토큰 삭제 구현 (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md — seat-reservation
+
+Spring Boot 기반 실시간 공연 좌석 예약 시스템.
+좌석 선점(HOLD)은 Redis, 예약 확정(RESERVED)은 MySQL에 저장한다.
+인증은 JWT Access Token + Opaque Refresh Token 방식. 웹 클라이언트 대상.
+
+도메인별 상세 규칙 → [`auth/CLAUDE.md`](src/main/java/com/demo/seatreservation/auth/CLAUDE.md) · [`seat/CLAUDE.md`](src/main/java/com/demo/seatreservation/seat/CLAUDE.md)
+
+---
+
+## 기술 스택
+
+| 항목 | 내용 |
+|------|------|
+| Java | 17 |
+| Spring Boot | 4.0.2 |
+| DB | MySQL 8 (port 3307) |
+| Cache/세션 | Redis 7 (port 6379) |
+| 인증 | Spring Security + JJWT 0.12.6 |
+| 빌드 | Gradle (Groovy) |
+| 테스트 | JUnit 5 + MockMvc + `@SpringBootTest` |
+
+---
+
+## 주요 명령어
+
+```bash
+docker-compose up -d          # MySQL + Redis 실행
+./gradlew build               # 전체 빌드
+./gradlew test                # 전체 테스트
+./gradlew bootRun             # 앱 실행
+```
+
+단일 테스트 클래스 실행:
+```bash
+./gradlew test --tests "com.demo.seatreservation.auth.controller.AuthLoginControllerTest"
+```
+
+---
+
+## 패키지 구조
+
+```
+src/main/java/com/demo/seatreservation/
+├── auth/           # 인증 모듈 → auth/CLAUDE.md
+├── seat/           # 좌석·예약 모듈 → seat/CLAUDE.md
+├── domain/         # JPA 엔티티 (User, Seat, Reservation) + enums/
+├── repository/     # JpaRepository 구현체
+├── security/
+│   ├── config/     # SecurityConfig, PasswordEncoder Bean
+│   └── jwt/        # JwtTokenProvider
+├── global/
+│   ├── config/     # RedisConfig
+│   └── exception/  # BusinessException, ErrorCode, GlobalExceptionHandler
+└── common/         # ApiResponse, ErrorResponse
+```
+
+---
+
+## 공통 코드 규칙
+
+### 엔티티
+- Lombok: `@Getter` + `@NoArgsConstructor(PROTECTED)` + `@AllArgsConstructor(PRIVATE)` + `@Builder`
+- 상태 전이는 엔티티 도메인 메서드로 (e.g., `reservation.cancel()`)
+- `@Enumerated(EnumType.STRING)` 필수, 컬럼명 snake_case, 테이블명 복수형 소문자
+
+### DTO
+- `dto/request/` · `dto/response/` 패키지 분리, request와 response 공유 금지
+- 검증: `@Valid` + `@NotBlank` / `@Email` / `@Size` 등
+
+### 서비스
+- `@Service` + `@RequiredArgsConstructor` (생성자 주입)
+- 조회: `@Transactional(readOnly = true)` / 쓰기: `@Transactional`
+- 여러 값 반환 시 내부 `record` 클래스 사용
+
+### 컨트롤러
+- 응답은 항상 `ApiResponse<T>`로 래핑
+- 비즈니스 로직 없음 — 서비스 위임만
+
+### 예외 처리
+- `BusinessException(ErrorCode)` 로 던지기
+- 새 에러 → `ErrorCode` 열거형에 추가
+- `GlobalExceptionHandler`의 `DataIntegrityViolationException` 핸들러는 DB UNIQUE 충돌 최종 방어선 — 건드리지 말 것
+
+### Redis
+- `StringRedisTemplate` 사용
+- 키 생성은 정적 팩토리 메서드 사용 (e.g., `HoldKey.of(showId, seatId)`)
+- **Redis 키 구조는 변경 금지** — 키 충돌 시 데이터 오염
+
+---
+
+## 공통 테스트 규칙
+
+- 모든 테스트: `@SpringBootTest` + `@AutoConfigureMockMvc`
+- `@BeforeEach`: Redis `flushAll()` + DB 초기 데이터 세팅
+- `@Transactional`으로 DB 롤백
+- **Mock 금지** — 실제 Redis·MySQL 연동으로 테스트
+- 테스트 메서드 이름: `{기능}_{조건}_{기대결과}()` (영어)
+- JSON body: 텍스트 블록(triple quote) + `.formatted()` 활용
+- 테스트 클래스 위치: 프로덕션 코드와 동일 패키지 구조

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.java.installations.paths=C:/Program Files/Java/jdk-17
+org.gradle.java.installations.auto-detect=true

--- a/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
@@ -1,0 +1,142 @@
+# auth/CLAUDE.md
+
+인증/인가 모듈 상세 규칙. 공통 규칙은 루트 `CLAUDE.md` 참고.
+
+---
+
+## 구현된 API
+
+| 메서드 | 경로 | 상태  | 설명 |
+|--------|------|-----|------|
+| POST | `/api/auth/signup` | 완료  | 회원가입 |
+| POST | `/api/auth/login` | 완료  | 로그인 |
+| POST | `/api/auth/refresh` | 완료  | Access Token 재발급 + Refresh Rotation |
+| POST | `/api/auth/logout` | 완료  | 현재 세션 로그아웃 |
+| POST | `/api/auth/logout-all` | 미구현 | 전체 세션 로그아웃 |
+
+---
+
+## 토큰 구조
+
+### Access Token (JWT)
+- 라이브러리: JJWT 0.12.6, 서명 알고리즘: HS256
+- 만료: 30분 (`access-token-expiration-ms: 1800000`)
+- Claims: `userId`, `email`, `role`, `sessionId` — 4개 모두 필수, 누락 금지
+- 전달: Response Body
+
+### Refresh Token (Opaque)
+- JWT가 아닌 랜덤 Base64 문자열 — **JWT로 변환 금지**
+- 만료: 14일 (`refresh-token-expiration-ms: 604800000`)
+- 서명 없음, Redis 저장값과 단순 문자열 비교로만 검증
+- 전달: `HttpOnly + Secure + SameSite=Strict` 쿠키, `Path=/api/auth/refresh`
+
+---
+
+## Redis 세션 구조
+
+```
+refresh:{userId}:{sessionId}    = refreshToken    (TTL 14일)
+refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
+```
+
+- 로그인마다 고유한 `sessionId` 생성 → 다중 기기 로그인 허용
+- `refresh:sessions:{userId}` Set으로 전체 세션 목록 추적
+- 키 구조 변경 금지 — logout-all 등 세션 전체 조회에 의존
+
+---
+
+## 각 API 처리 흐름
+
+### 로그인 (`/api/auth/login`)
+1. `findByEmail()` — 없으면 `INVALID_CREDENTIALS`
+2. `passwordEncoder.matches()` — 틀리면 `INVALID_CREDENTIALS`
+3. `sessionId` 생성
+4. Access Token(JWT) 생성
+5. Opaque Refresh Token 생성
+6. Redis: `refresh:{userId}:{sessionId}` = refreshToken 저장
+7. Redis: `refresh:sessions:{userId}` Set에 sessionId 추가
+8. Access Token → Response Body, Refresh Token → Set-Cookie
+
+### Refresh (`/api/auth/refresh`)
+1. 쿠키에 refreshToken 없으면 → `UNAUTHORIZED`
+2. Access Token claims에서 `userId`, `sessionId` 추출
+3. Redis에서 `refresh:{userId}:{sessionId}` 조회 — 없으면 `INVALID_REFRESH_TOKEN`
+4. 저장값과 요청값 비교 — 불일치 시 해당 키 삭제 + sessionId Set에서 제거 + `INVALID_REFRESH_TOKEN`
+5. 새 Access Token 발급
+6. 새 Refresh Token 발급 (Rotation)
+7. Redis 저장값 갱신 (기존 토큰 즉시 무효화)
+8. sessionId는 유지
+
+### Logout (`/api/auth/logout`) — 미구현
+1. Access Token 검증 (유효한 토큰 없으면 401 — 만료 시 먼저 refresh 필요)
+2. claims에서 `userId`, `sessionId` 추출
+3. Redis: `refresh:{userId}:{sessionId}` 삭제
+4. Redis: `refresh:sessions:{userId}` Set에서 sessionId 제거
+5. 응답 쿠키 maxAge=0으로 만료 처리
+
+### Logout-All (`/api/auth/logout-all`) — 미구현
+1. Access Token 검증
+2. claims에서 `userId` 추출
+3. Redis: `refresh:sessions:{userId}` Set에서 모든 sessionId 조회
+4. 각 sessionId에 대해 `refresh:{userId}:{sessionId}` 삭제
+5. Redis: `refresh:sessions:{userId}` Set 삭제
+6. 응답 쿠키 만료 처리
+
+---
+
+## 보안 정책
+
+- Refresh Token 불일치 감지 시 → 해당 세션 즉시 삭제 (토큰 탈취 의심 처리)
+- `POST /api/auth/refresh`는 쿠키 기반 — SameSite=Strict, Path 제한으로 CSRF 방어
+- logout은 유효한 Access Token이 있을 때만 가능, 만료 시 클라이언트에서 토큰만 삭제하거나 refresh 후 logout
+
+---
+
+## ErrorCode
+
+| 코드 | HTTP | 설명 |
+|------|------|------|
+| `EMAIL_DUPLICATED` | 409 | 이미 가입된 이메일 |
+| `INVALID_CREDENTIALS` | 401 | 이메일 없음 또는 비밀번호 불일치 |
+| `INVALID_REFRESH_TOKEN` | 401 | Redis 없음 또는 불일치 |
+| `UNAUTHORIZED` | 401 | 쿠키 없음 또는 Access Token 없음/만료 |
+
+---
+
+## 테스트 규칙
+
+- 테스트 클래스 위치: `test/.../auth/controller/`
+- `@BeforeEach`: Redis `flushAll()` + (필요 시) User 저장
+- Refresh Token 검증은 Redis 직접 조회로 확인
+- 쿠키 검증: `mockMvc` 응답의 `Set-Cookie` 헤더 확인
+
+### 필수 테스트 시나리오
+
+**로그인**
+- 성공 시 access token body 반환, refresh token 쿠키 반환
+- 이메일 없음 → 401
+- 비밀번호 불일치 → 401
+- Redis에 `refresh:{userId}:{sessionId}` 저장 확인
+- `refresh:sessions:{userId}` Set에 sessionId 추가 확인
+- 동일 계정 여러 번 로그인 시 각각 다른 sessionId로 저장
+
+**Refresh**
+- 성공 시 access/refresh 모두 새로 발급
+- 이전 refresh token 재사용 시 실패
+- 쿠키 없으면 401
+- Redis 값 불일치 → 해당 세션 삭제 후 401
+- A 기기 logout 후 B 기기 refresh는 여전히 성공
+
+**Logout (구현 후)**
+- Redis refresh token 삭제 확인
+- `refresh:sessions:{userId}` Set에서 sessionId 제거 확인
+- 다른 기기 refresh token 유지 확인
+- 로그아웃된 세션의 refresh token 재사용 불가
+- 응답 쿠키 만료 처리 확인
+
+**Logout-All (구현 후)**
+- 여러 기기 로그인 후 logout-all 시 모든 refresh token 삭제
+- `refresh:sessions:{userId}` Set 삭제 확인
+- 모든 기기에서 refresh 실패 확인
+- 다른 사용자의 refresh token은 삭제되지 않음
+- logout-all 후 재로그인으로 새 세션 정상 생성 확인

--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -8,10 +8,12 @@ import com.demo.seatreservation.auth.util.RefreshTokenCookieProvider;
 import com.demo.seatreservation.common.ApiResponse;
 import com.demo.seatreservation.global.exception.BusinessException;
 import com.demo.seatreservation.global.exception.ErrorCode;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -47,6 +49,24 @@ public class AuthController {
                 )
                 .body(ApiResponse.ok(result.loginResponse()));
 
+    }
+
+    /**
+     * 현재 세션 로그아웃
+     *
+     * - JwtAuthenticationFilter가 검증한 Principal에서 userId / sessionId 추출
+     * - Redis에서 해당 세션 refresh 데이터 삭제
+     * - refresh cookie 만료 처리
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        authService.logout(principal.getUserId(), principal.getSessionId());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.deleteCookie().toString())
+                .body(ApiResponse.ok(null));
     }
 
     /**

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -231,6 +231,23 @@ public class AuthService {
     }
 
     /**
+     * 현재 세션 로그아웃
+     * - JwtAuthenticationFilter가 검증한 Principal에서 userId / sessionId 수신
+     * - Redis에서 해당 세션 refresh 데이터 전부 삭제
+     */
+    public void logout(Long userId, String sessionId) {
+        String refreshKey = "refresh:" + userId + ":" + sessionId;
+
+        String storedRefreshToken = stringRedisTemplate.opsForValue().get(refreshKey);
+        if (storedRefreshToken != null) {
+            stringRedisTemplate.delete("refresh:token:" + storedRefreshToken);
+        }
+
+        stringRedisTemplate.delete(refreshKey);
+        stringRedisTemplate.opsForSet().remove("refresh:sessions:" + userId, sessionId);
+    }
+
+    /**
      * refresh token 검증 실패 시
      * 해당 세션의 refresh 관련 데이터 삭제
      */

--- a/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
@@ -1,0 +1,156 @@
+# seat/CLAUDE.md
+
+좌석 선점·예약·취소 모듈 상세 규칙. 공통 규칙은 루트 `CLAUDE.md` 참고.
+
+---
+
+## 구현된 API
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| POST | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 생성 |
+| DELETE | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 취소 |
+| GET | `/api/shows/{showId}/seats` | 불필요 | 실시간 좌석 상태 조회 |
+| POST | `/api/seats/{seatId}/reservations` | 필요 (미적용) | 예약 확정 |
+| GET | `/api/users/{userId}/reservations` | 필요 (미적용) | 내 예약 조회 |
+| DELETE | `/api/reservations/{reservationId}` | 필요 (미적용) | 예약 취소 |
+
+> JWT 필터 적용 후 userId 직접 전달 방식 제거 예정 (`?userId=`, RequestBody userId 모두 제거)
+
+---
+
+## 도메인 규칙
+
+| 규칙 | 내용 |
+|------|------|
+| HOLD TTL | 300초 (5분), Redis 키 자동 만료 |
+| 최대 HOLD 수 | 동일 공연 내 userId당 4석 |
+| HOLD 소유권 | 생성한 userId만 취소·확정 가능 |
+| 예약 취소 대상 | RESERVED 상태만 가능 |
+| 취소 후 HOLD 복구 | 없음 — 취소는 확정 해제, 선점 자동 생성 안 함 |
+
+---
+
+## 좌석 상태 우선순위
+
+실시간 조회(`SeatQueryFacade`) 시 상태 판단 순서:
+
+```
+1. DB에 RESERVED → RESERVED 반환
+2. Redis에 HOLD → HELD 반환
+3. 둘 다 없음 → AVAILABLE 반환
+```
+
+**RESERVED + HOLD 동시 존재 시 반드시 RESERVED 우선** — 역순으로 구현하면 안 됨.
+
+---
+
+## Redis HOLD 구조
+
+```
+hold:{showId}:{seatId}          = userId        (TTL 300s, NX 플래그로 원자적 생성)
+hold:user:{showId}:{userId}     = Set<seatId>   (hold 개수 추적, TTL 동기화 필요)
+```
+
+- `tryHold()`의 NX 플래그 제거 금지 — 동시 요청 시 원자성 보장에 필수
+- 키 구조 변경 금지 — hold 개수 추적, TTL 관리 로직이 이 구조에 의존
+
+---
+
+## 각 API 처리 흐름
+
+### HOLD 생성 (`POST /api/seats/{seatId}/hold`)
+1. DB에 해당 좌석 RESERVED 여부 확인 → 있으면 `ALREADY_RESERVED`
+2. Redis `hold:user:{showId}:{userId}` Set 크기 확인 → 4 이상이면 `HOLD_LIMIT_EXCEEDED`
+3. Redis `hold:{showId}:{seatId}` NX + TTL 300s 설정 시도 → 실패 시 `SEAT_ALREADY_HELD`
+4. `hold:user:{showId}:{userId}` Set에 seatId 추가
+5. 응답: seatId, showId, status=HELD, expiresInSec
+
+### HOLD 취소 (`DELETE /api/seats/{seatId}/hold`)
+1. Redis `hold:{showId}:{seatId}` 조회 → 없으면 `HOLD_EXPIRED`
+2. 저장된 userId와 요청 userId 비교 → 불일치 시 `NOT_HOLD_OWNER`
+3. Redis 키 삭제
+4. `hold:user:{showId}:{userId}` Set에서 seatId 제거
+5. 응답: status=AVAILABLE
+
+### 예약 확정 (`POST /api/seats/{seatId}/reservations`)
+1. Redis HOLD 존재 확인 → 없으면 `HOLD_EXPIRED`
+2. HOLD 소유자 확인 → 불일치 시 `NOT_HOLD_OWNER`
+3. DB에 RESERVED 존재 사전 확인 → 있으면 `ALREADY_RESERVED`
+4. DB 트랜잭션: Reservation 저장 (status=RESERVED)
+5. Redis HOLD 키 삭제 + `hold:user` Set에서 seatId 제거
+6. DB UNIQUE 충돌 시 → `ALREADY_RESERVED` (최종 방어)
+
+### 예약 취소 (`DELETE /api/reservations/{reservationId}`)
+1. DB에서 예약 조회 → 없으면 `RESERVATION_NOT_FOUND`
+2. 예약 소유자 확인 → 불일치 시 `NOT_RESERVATION_OWNER`
+3. 상태 확인 → CANCELED이면 `ALREADY_CANCELED`
+4. `reservation.cancel()` 도메인 메서드 호출 → 상태 CANCELED 변경
+5. Redis HOLD 복구 없음
+
+---
+
+## 소유권 검사 원칙
+
+소유권 검사는 Spring Security 레벨이 아닌 **서비스 레벨**에서 처리.
+
+- Hold 소유권: `SeatHoldService` 내부에서 Redis 저장값과 비교
+- 예약 소유권: `ReservationService` 내부에서 `reservation.getUserId().equals(userId)` 비교
+- 불일치 시 `BusinessException(ErrorCode.NOT_HOLD_OWNER)` / `NOT_RESERVATION_OWNER`
+
+---
+
+## ErrorCode
+
+| 코드 | HTTP | 설명 |
+|------|------|------|
+| `SEAT_ALREADY_HELD` | 409 | 이미 다른 사용자가 HOLD 중 |
+| `HOLD_EXPIRED` | 409 | HOLD 없음 (만료 또는 미존재) |
+| `HOLD_LIMIT_EXCEEDED` | 409 | 동일 공연에서 4석 초과 시도 |
+| `NOT_HOLD_OWNER` | 403 | HOLD 소유자 불일치 |
+| `ALREADY_RESERVED` | 409 | 이미 RESERVED 상태인 좌석 |
+| `RESERVATION_NOT_FOUND` | 404 | 예약 없음 |
+| `NOT_RESERVATION_OWNER` | 403 | 예약 소유자 불일치 |
+| `ALREADY_CANCELED` | 409 | 이미 취소된 예약 |
+
+---
+
+## 테스트 규칙
+
+- 테스트 클래스 위치: `test/.../seat/controller/`
+- `@BeforeEach`: Redis `flushAll()` + Seat·User·Reservation 데이터 직접 저장
+- HOLD 생성 후 Redis TTL 값 직접 확인 (`stringRedisTemplate.getExpire()`)
+- 동시성 테스트 필요 시 `CountDownLatch` + 멀티 스레드 활용
+
+### 필수 테스트 시나리오
+
+**HOLD 생성**
+- 성공 시 Redis 키 생성 + TTL 확인
+- 동일 좌석 두 번 hold → `SEAT_ALREADY_HELD`
+- TTL 만료 후 재 hold 성공
+- DB RESERVED 좌석 hold → `ALREADY_RESERVED`
+- 4석 초과 hold → `HOLD_LIMIT_EXCEEDED`
+- hold 취소 후 개수 감소 확인
+
+**HOLD 취소**
+- 다른 userId로 취소 → `NOT_HOLD_OWNER`
+- 만료된 hold 취소 → `HOLD_EXPIRED`
+- 취소 후 해당 좌석 AVAILABLE로 조회
+
+**예약 확정**
+- 성공 후 조회에서 RESERVED 상태 확인
+- 동일 좌석 confirm 두 번 → `ALREADY_RESERVED`
+- HOLD 없이 confirm → `HOLD_EXPIRED`
+- 다른 userId로 confirm → `NOT_HOLD_OWNER`
+- DB RESERVED 존재 상태에서 confirm → `ALREADY_RESERVED`
+
+**좌석 조회**
+- HOLD 걸면 HELD로 보이는지 확인
+- TTL 지나면 AVAILABLE로 돌아오는지 확인
+- RESERVED + HOLD 동시 존재 시 RESERVED 반환 확인
+
+**예약 취소**
+- 성공 후 내 예약 조회에서 미노출 확인
+- 다른 userId로 취소 → `NOT_RESERVATION_OWNER`
+- 이미 취소된 예약 재취소 → `ALREADY_CANCELED`
+- 존재하지 않는 예약 → `RESERVATION_NOT_FOUND`

--- a/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -1,24 +1,43 @@
 package com.demo.seatreservation.security.config;
 
+import com.demo.seatreservation.security.filter.JwtAuthenticationFilter;
+import com.demo.seatreservation.security.handler.JwtAccessDeniedHandler;
+import com.demo.seatreservation.security.handler.JwtAuthenticationEntryPoint;
+import com.demo.seatreservation.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(
-                        org.springframework.security.config.http.SessionCreationPolicy.STATELESS
-                ))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/signup",
@@ -27,7 +46,8 @@ public class SecurityConfig {
                                 "/api/shows/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/demo/seatreservation/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/demo/seatreservation/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.demo.seatreservation.security.filter;
+
+import com.demo.seatreservation.security.jwt.JwtTokenProvider;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = extractBearerToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserId(token);
+            String email = jwtTokenProvider.getEmail(token);
+            String role = jwtTokenProvider.getRole(token);
+            String sessionId = jwtTokenProvider.getSessionId(token);
+
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, email, role, sessionId);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractBearerToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/demo/seatreservation/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/demo/seatreservation/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.demo.seatreservation.security.handler;
+
+import com.demo.seatreservation.common.ErrorResponse;
+import com.demo.seatreservation.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ErrorCode.FORBIDDEN.name(),
+                ErrorCode.FORBIDDEN.message(),
+                request.getRequestURI()
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/demo/seatreservation/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/demo/seatreservation/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.demo.seatreservation.security.handler;
+
+import com.demo.seatreservation.common.ErrorResponse;
+import com.demo.seatreservation.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ErrorCode.UNAUTHORIZED.name(),
+                ErrorCode.UNAUTHORIZED.message(),
+                request.getRequestURI()
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/demo/seatreservation/security/principal/CustomUserPrincipal.java
+++ b/src/main/java/com/demo/seatreservation/security/principal/CustomUserPrincipal.java
@@ -1,0 +1,70 @@
+package com.demo.seatreservation.security.principal;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserPrincipal implements UserDetails {
+
+    private final Long userId;
+    private final String email;
+    private final String role;
+    private final String sessionId;
+
+    public CustomUserPrincipal(Long userId, String email, String role, String sessionId) {
+        this.userId = userId;
+        this.email = email;
+        this.role = role;
+        this.sessionId = sessionId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthLogoutControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthLogoutControllerTest.java
@@ -1,0 +1,231 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.domain.enums.Role;
+import com.demo.seatreservation.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Set;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthLogoutControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired StringRedisTemplate stringRedisTemplate;
+    @Autowired ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        Set<String> refreshKeys = stringRedisTemplate.keys("refresh:*");
+        if (refreshKeys != null && !refreshKeys.isEmpty()) {
+            stringRedisTemplate.delete(refreshKeys);
+        }
+    }
+
+    private User saveUser(String email, String rawPassword, String name, String phone) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(rawPassword))
+                        .name(name)
+                        .phone(phone)
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private LoginResult loginAndGetResult(String email, String password) throws Exception {
+        String body = """
+                {
+                  "email": "%s",
+                  "password": "%s"
+                }
+                """.formatted(email, password);
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        String sessionId = root.get("data").get("sessionId").asText();
+        String accessToken = root.get("data").get("accessToken").asText();
+        String refreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
+
+        return new LoginResult(sessionId, accessToken, refreshToken);
+    }
+
+    @Test
+    void logout_success_deletesRefreshTokenFromRedis() throws Exception {
+
+        // 테스트 목적:
+        // logout 성공 시 현재 세션의 refresh token이 Redis에서 삭제되어야 한다
+
+        User user = saveUser("logout@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("logout@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        String refreshKey = "refresh:" + user.getId() + ":" + login.sessionId();
+        assertThat(stringRedisTemplate.hasKey(refreshKey)).isFalse();
+
+        String lookupKey = "refresh:token:" + login.refreshToken();
+        assertThat(stringRedisTemplate.hasKey(lookupKey)).isFalse();
+    }
+
+    @Test
+    void logout_removesSessionId_fromSessionSet() throws Exception {
+
+        // 테스트 목적:
+        // logout 성공 시 refresh:sessions:{userId} Set에서 sessionId가 제거되어야 한다
+        User user = saveUser("session@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("session@test.com", "12345678");
+
+        String sessionSetKey = "refresh:sessions:" + user.getId();
+        assertThat(stringRedisTemplate.opsForSet().isMember(sessionSetKey, login.sessionId())).isTrue();
+
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        assertThat(stringRedisTemplate.opsForSet().isMember(sessionSetKey, login.sessionId())).isFalse();
+    }
+
+    @Test
+    void logout_otherDeviceSession_preserved() throws Exception {
+
+        // 테스트 목적:
+        // A 기기 logout 시 B 기기의 refresh token은 삭제되지 않아야 한다
+        User user = saveUser("multi@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("multi@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("multi@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        String refreshKeyB = "refresh:" + user.getId() + ":" + deviceB.sessionId();
+        assertThat(stringRedisTemplate.hasKey(refreshKeyB)).isTrue();
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceB.refreshToken()))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(deviceB.sessionId()));
+    }
+
+    @Test
+    void logout_loggedOutSession_refreshTokenUnusable() throws Exception {
+
+        // 테스트 목적:
+        // logout한 세션의 refresh token은 이후 재사용할 수 없어야 한다
+        saveUser("reuse@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("reuse@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", login.refreshToken()))
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+    }
+
+    @Test
+    void logout_expiresRefreshCookie() throws Exception {
+
+        // 테스트 목적:
+        // logout 응답에 refresh cookie 만료 처리가 내려와야 한다
+        saveUser("cookie@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("cookie@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("Max-Age=0")))
+                .andExpect(header().string("Set-Cookie", containsString("Path=/api/auth/refresh")));
+    }
+
+    @Test
+    void logout_noAuthorizationHeader_returns401() throws Exception {
+
+        // 테스트 목적:
+        // Authorization 헤더가 없으면 401 UNAUTHORIZED가 발생해야 한다
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void logout_invalidAccessToken_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 유효하지 않은 access token으로 logout 시도 시 401 UNAUTHORIZED가 발생해야 한다
+        mockMvc.perform(
+                        post("/api/auth/logout")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.value")
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    private String extractRefreshTokenFromCookie(String setCookieHeader) {
+        if (setCookieHeader == null) return null;
+        for (String part : setCookieHeader.split(";")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("refreshToken=")) {
+                return trimmed.substring("refreshToken=".length());
+            }
+        }
+        return null;
+    }
+
+    private record LoginResult(String sessionId, String accessToken, String refreshToken) {}
+}


### PR DESCRIPTION
## 현재 세션 로그아웃 API 구현
- JWT Access Token 검증 후 현재 사용자 식별
- `SecurityContext` 기반 사용자 정보 사용
- 현재 세션의 refresh token 삭제
- `refresh:token:{refreshToken}` 역조회 키 삭제
- `refresh:{userId}:{sessionId}` 삭제
- `refresh:sessions:{userId}`에서 sessionId 제거
- refresh cookie 만료 처리
- 로그아웃 관련 테스트 코드 추가

자세한 설명은 이슈 #38 확인

## 테스트 
- logout 성공 시 Redis refresh token 삭제 확인
- `refresh:sessions:{userId}`에서 현재 sessionId 제거 확인
- 다른 기기 세션은 유지되는지 확인
- logout한 세션의 refresh token 재사용 실패 확인
- logout 시 refresh cookie 만료 확인