### PR TITLE
[feat/auth-lgout-all] 전체 세션 로그아웃 및 refresh 토큰 정리 기능 구현 #(43)

### DIFF
--- a/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
@@ -12,7 +12,7 @@
 | POST | `/api/auth/login` | 완료  | 로그인 |
 | POST | `/api/auth/refresh` | 완료  | Access Token 재발급 + Refresh Rotation |
 | POST | `/api/auth/logout` | 완료  | 현재 세션 로그아웃 |
-| POST | `/api/auth/logout-all` | 미구현 | 전체 세션 로그아웃 |
+| POST | `/api/auth/logout-all` | 완료  | 전체 세션 로그아웃 |
 
 ---
 
@@ -80,7 +80,10 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 1. Access Token 검증
 2. claims에서 `userId` 추출
 3. Redis: `refresh:sessions:{userId}` Set에서 모든 sessionId 조회
-4. 각 sessionId에 대해 `refresh:{userId}:{sessionId}` 삭제
+4. 각 sessionId에 대해:
+   - `refresh:{userId}:{sessionId}` 조회 → stored refreshToken 획득
+   - `refresh:token:{refreshToken}` 역조회 키 삭제
+   - `refresh:{userId}:{sessionId}` 삭제
 5. Redis: `refresh:sessions:{userId}` Set 삭제
 6. 응답 쿠키 만료 처리
 
@@ -138,7 +141,10 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 
 **Logout-All (구현 후)**
 - 여러 기기 로그인 후 logout-all 시 모든 refresh token 삭제
+- 각 sessionId에 대응하는 `refresh:token:{refreshToken}` 역조회 키 삭제 확인
 - `refresh:sessions:{userId}` Set 삭제 확인
 - 모든 기기에서 refresh 실패 확인
 - 다른 사용자의 refresh token은 삭제되지 않음
 - logout-all 후 재로그인으로 새 세션 정상 생성 확인
+- Authorization 헤더 없이 logout-all 요청 → 401
+- 유효하지 않은 access token으로 logout-all 요청 → 401

--- a/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
+++ b/src/main/java/com/demo/seatreservation/auth/controller/AuthController.java
@@ -70,6 +70,24 @@ public class AuthController {
     }
 
     /**
+     * 전체 세션 로그아웃
+     *
+     * - JwtAuthenticationFilter가 검증한 Principal에서 userId 추출
+     * - 해당 유저의 모든 세션 refresh 데이터 삭제
+     * - refresh cookie 만료 처리
+     */
+    @PostMapping("/logout-all")
+    public ResponseEntity<ApiResponse<Void>> logoutAll(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        authService.logoutAll(principal.getUserId());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.deleteCookie().toString())
+                .body(ApiResponse.ok(null));
+    }
+
+    /**
      * Access Token 재발급 (Refresh Token Rotation)
      *
      * - refresh token -> HttpOnly 쿠키에서 추출

--- a/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Set;
 import java.util.UUID;
 
 import java.security.SecureRandom;
@@ -240,6 +241,28 @@ public class AuthService {
 
         stringRedisTemplate.delete(refreshKey);
         stringRedisTemplate.opsForSet().remove("refresh:sessions:" + userId, sessionId);
+    }
+
+    /**
+     * 전체 세션 로그아웃
+     * - 해당 유저의 모든 세션 refresh 데이터 삭제
+     */
+    public void logoutAll(Long userId) {
+        String sessionSetKey = "refresh:sessions:" + userId;
+
+        Set<String> sessionIds = stringRedisTemplate.opsForSet().members(sessionSetKey);
+        if (sessionIds != null) {
+            for (String sessionId : sessionIds) {
+                String refreshKey = "refresh:" + userId + ":" + sessionId;
+                String storedToken = stringRedisTemplate.opsForValue().get(refreshKey);
+                if (storedToken != null) {
+                    stringRedisTemplate.delete("refresh:token:" + storedToken);
+                }
+                stringRedisTemplate.delete(refreshKey);
+            }
+        }
+
+        stringRedisTemplate.delete(sessionSetKey);
     }
 
     /**

--- a/src/test/java/com/demo/seatreservation/auth/controller/AuthLogoutAllControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/auth/controller/AuthLogoutAllControllerTest.java
@@ -1,0 +1,331 @@
+package com.demo.seatreservation.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.demo.seatreservation.domain.User;
+import com.demo.seatreservation.domain.enums.Role;
+import com.demo.seatreservation.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Set;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthLogoutAllControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired StringRedisTemplate stringRedisTemplate;
+    @Autowired ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        Set<String> refreshKeys = stringRedisTemplate.keys("refresh:*");
+        if (refreshKeys != null && !refreshKeys.isEmpty()) {
+            stringRedisTemplate.delete(refreshKeys);
+        }
+    }
+
+    private User saveUser(String email, String rawPassword, String name, String phone) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(rawPassword))
+                        .name(name)
+                        .phone(phone)
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private LoginResult loginAndGetResult(String email, String password) throws Exception {
+        String body = """
+                {
+                  "email": "%s",
+                  "password": "%s"
+                }
+                """.formatted(email, password);
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        String sessionId = root.get("data").get("sessionId").asText();
+        String accessToken = root.get("data").get("accessToken").asText();
+        String refreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
+
+        return new LoginResult(sessionId, accessToken, refreshToken);
+    }
+
+    @Test
+    void logoutAll_success_deletesAllRefreshTokensFromRedis() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 성공 시 해당 유저의 모든 세션 refresh token이 Redis에서 삭제되어야 한다
+
+        User user = saveUser("all@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("all@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("all@test.com", "12345678");
+        LoginResult deviceC = loginAndGetResult("all@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        assertThat(stringRedisTemplate.hasKey("refresh:" + user.getId() + ":" + deviceA.sessionId())).isFalse();
+        assertThat(stringRedisTemplate.hasKey("refresh:" + user.getId() + ":" + deviceB.sessionId())).isFalse();
+        assertThat(stringRedisTemplate.hasKey("refresh:" + user.getId() + ":" + deviceC.sessionId())).isFalse();
+    }
+
+    @Test
+    void logoutAll_success_deletesAllReverseLookupKeys() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 성공 시 각 sessionId에 대응하는 refresh:token:{refreshToken} 역조회 키도 삭제되어야 한다
+
+        saveUser("lookup@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("lookup@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("lookup@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        assertThat(stringRedisTemplate.hasKey("refresh:token:" + deviceA.refreshToken())).isFalse();
+        assertThat(stringRedisTemplate.hasKey("refresh:token:" + deviceB.refreshToken())).isFalse();
+    }
+
+    @Test
+    void logoutAll_success_deletesSessionSet() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 성공 시 refresh:sessions:{userId} Set이 삭제되어야 한다
+
+        User user = saveUser("set@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("set@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        assertThat(stringRedisTemplate.hasKey("refresh:sessions:" + user.getId())).isFalse();
+    }
+
+    @Test
+    void logoutAll_deviceA_refreshFails() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 이후 A 기기의 refresh token으로 재발급을 시도하면 실패해야 한다
+
+        saveUser("deva@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("deva@test.com", "12345678");
+        loginAndGetResult("deva@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceA.refreshToken()))
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+    }
+
+    @Test
+    void logoutAll_deviceB_refreshFails() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 이후 B 기기의 refresh token으로 재발급을 시도하면 실패해야 한다
+
+        saveUser("devb@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("devb@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("devb@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceB.refreshToken()))
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+    }
+
+    @Test
+    void logoutAll_deviceC_refreshFails() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 이후 C 기기의 refresh token으로 재발급을 시도하면 실패해야 한다
+
+        saveUser("devc@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult deviceA = loginAndGetResult("devc@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("devc@test.com", "12345678");
+        LoginResult deviceC = loginAndGetResult("devc@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + deviceA.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceC.refreshToken()))
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+
+        // deviceB 추가 검증
+        assertThat(stringRedisTemplate.hasKey("refresh:token:" + deviceB.refreshToken())).isFalse();
+    }
+
+    @Test
+    void logoutAll_otherUserSession_preserved() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 시 다른 사용자의 refresh token은 삭제되지 않아야 한다
+
+        saveUser("user1@test.com", "12345678", "홍길동", "010-1111-2222");
+        User user2 = saveUser("user2@test.com", "12345678", "김철수", "010-3333-4444");
+
+        LoginResult user1Login = loginAndGetResult("user1@test.com", "12345678");
+        LoginResult user2Login = loginAndGetResult("user2@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + user1Login.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        String user2RefreshKey = "refresh:" + user2.getId() + ":" + user2Login.sessionId();
+        assertThat(stringRedisTemplate.hasKey(user2RefreshKey)).isTrue();
+        assertThat(stringRedisTemplate.hasKey("refresh:token:" + user2Login.refreshToken())).isTrue();
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", user2Login.refreshToken()))
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void logoutAll_thenLogin_newSessionCreated() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 이후 다시 로그인하면 새로운 session으로 정상 로그인 가능해야 한다
+
+        User user = saveUser("relogin@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult before = loginAndGetResult("relogin@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + before.accessToken())
+                )
+                .andExpect(status().isOk());
+
+        LoginResult after = loginAndGetResult("relogin@test.com", "12345678");
+
+        assertThat(after.sessionId()).isNotEqualTo(before.sessionId());
+        assertThat(stringRedisTemplate.hasKey("refresh:" + user.getId() + ":" + after.sessionId())).isTrue();
+        assertThat(stringRedisTemplate.opsForSet().isMember("refresh:sessions:" + user.getId(), after.sessionId())).isTrue();
+    }
+
+    @Test
+    void logoutAll_expiresRefreshCookie() throws Exception {
+
+        // 테스트 목적:
+        // logout-all 응답에 refresh cookie 만료 처리가 내려와야 한다
+
+        saveUser("cookie@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult login = loginAndGetResult("cookie@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + login.accessToken())
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("Max-Age=0")))
+                .andExpect(header().string("Set-Cookie", containsString("Path=/api/auth/refresh")));
+    }
+
+    @Test
+    void logoutAll_noAuthorizationHeader_returns401() throws Exception {
+
+        // 테스트 목적:
+        // Authorization 헤더가 없으면 401 UNAUTHORIZED가 발생해야 한다
+
+        mockMvc.perform(post("/api/auth/logout-all"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void logoutAll_invalidAccessToken_returns401() throws Exception {
+
+        // 테스트 목적:
+        // 유효하지 않은 access token으로 logout-all 시도 시 401 UNAUTHORIZED가 발생해야 한다
+
+        mockMvc.perform(
+                        post("/api/auth/logout-all")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.value")
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    private String extractRefreshTokenFromCookie(String setCookieHeader) {
+        if (setCookieHeader == null) return null;
+        for (String part : setCookieHeader.split(";")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("refreshToken=")) {
+                return trimmed.substring("refreshToken=".length());
+            }
+        }
+        return null;
+    }
+
+    private record LoginResult(String sessionId, String accessToken, String refreshToken) {}
+}


### PR DESCRIPTION
### 1. Logout-All API 구현
- Access Token 기반 현재 사용자 식별
- Redis에 저장된 해당 사용자의 모든 세션 정보 삭제

### 2. Redis 세션 정리 로직 구현
다음 키들을 모두 삭제하도록 구현:
- `refresh:{userId}:{sessionId}` (세션별 refresh token)
- `refresh:token:{refreshToken}` (역조회 키)
- `refresh:sessions:{userId}` (세션 목록 Set)

→ logout-all 이후 모든 기기에서 refresh 재발급 불가 상태 보장

자세한 내용은 이슈 #43 확인

### 테스트
- 여러 기기 로그인 상태에서 logout-all 성공
- 모든 `refresh:{userId}:{sessionId}` 삭제 확인
- `refresh:token:{refreshToken}` 역조회 키 삭제 확인
- `refresh:sessions:{userId}` Set 삭제 확인
- logout-all 이후 A/B/C 기기 refresh 실패 확인
- 다른 사용자 세션 유지 확인
- logout-all 이후 재로그인 정상 동작 확인
- refresh cookie 만료 응답 확인
- Authorization 헤더 없음 → 401
- 유효하지 않은 Access Token → 401