### PR TITLE
[fix/security-show-public-scope] 공연 조회 API 공개 범위 제한

### DIFF
--- a/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
@@ -10,7 +10,7 @@
 |--------|------|------|------|
 | POST | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 생성 |
 | DELETE | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 취소 |
-| GET | `/api/shows/{showId}/seats` | 불필요 | 실시간 좌석 상태 조회 |
+| GET | `/api/shows/{showId}/seats` | 불필요 (GET `/api/shows/**` 공개) | 실시간 좌석 상태 조회 |
 | POST | `/api/seats/{seatId}/reservations` | 필요 (미적용) | 예약 확정 |
 | GET | `/api/users/{userId}/reservations` | 필요 (미적용) | 내 예약 조회 |
 | DELETE | `/api/reservations/{reservationId}` | 필요 (미적용) | 예약 취소 |

--- a/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.demo.seatreservation.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -42,9 +43,9 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/signup",
                                 "/api/auth/login",
-                                "/api/auth/refresh",
-                                "/api/shows/**"
+                                "/api/auth/refresh"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/shows/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 작업 내용
### 1. SecurityConfig 수정
- 기존:
  - `/api/shows/**` → permitAll (전체 공개 ❌)
- 변경:
  - `GET /api/shows/**` → permitAll
  - 그 외 요청 → authenticated

자세한 설명은 이슈 #45 확인