### PR TITLE
[fix/public-api-security-config] 좌석 조회 및 헬스체크 API 공개 설정 #(47)

### DIFF
--- a/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
@@ -10,10 +10,10 @@
 |--------|------|------|------|
 | POST | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 생성 |
 | DELETE | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 취소 |
-| GET | `/api/shows/{showId}/seats` | 불필요 (GET `/api/shows/**` 공개) | 실시간 좌석 상태 조회 |
-| POST | `/api/seats/{seatId}/reservations` | 필요 (미적용) | 예약 확정 |
-| GET | `/api/users/{userId}/reservations` | 필요 (미적용) | 내 예약 조회 |
-| DELETE | `/api/reservations/{reservationId}` | 필요 (미적용) | 예약 취소 |
+| GET | `/api/seats` | 불필요 (GET `/api/seats` 공개) | 실시간 좌석 상태 조회 (`?showId=` 쿼리 파라미터) |
+| POST | `/api/reservations/confirm` | 필요 (미적용) | 예약 확정 |
+| GET | `/api/me/reservations` | 필요 (미적용) | 내 예약 조회 (`?userId=` 쿼리 파라미터) |
+| POST | `/api/reservations/{reservationId}/cancel` | 필요 (미적용) | 예약 취소 |
 
 > JWT 필터 적용 후 userId 직접 전달 방식 제거 예정 (`?userId=`, RequestBody userId 모두 제거)
 

--- a/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/refresh"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/shows/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/shows/**", "/api/seats", "/", "/health").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 작업 내용

- `GET /api/seats`를 공개 API로 설정
- `GET /`, `GET /health`를 공개 API로 설정
- `GET /api/shows/**`는 추후 공연 조회 API를 고려하여 GET 공개 규칙으로 유지
- `GET /test-error`는 공개하지 않고 보호 상태 유지
- 그 외 요청은 기존처럼 인증 필요 상태 유지

자세한 내용은 이슈 #47 확인