### PR TITLE
[refactor/use-printipal-user-id] Principal 기반 userId 처리로 보호 API 개선 (#49)

### DIFF
--- a/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
+++ b/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
@@ -8,14 +8,12 @@
 
 | 메서드 | 경로 | 인증 | 설명 |
 |--------|------|------|------|
-| POST | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 생성 |
-| DELETE | `/api/seats/{seatId}/hold` | 필요 (미적용) | HOLD 취소 |
+| POST | `/api/seats/{seatId}/hold` | 필요 (적용) | HOLD 생성 |
+| DELETE | `/api/seats/{seatId}/hold` | 필요 (적용) | HOLD 취소 |
 | GET | `/api/seats` | 불필요 (GET `/api/seats` 공개) | 실시간 좌석 상태 조회 (`?showId=` 쿼리 파라미터) |
-| POST | `/api/reservations/confirm` | 필요 (미적용) | 예약 확정 |
-| GET | `/api/me/reservations` | 필요 (미적용) | 내 예약 조회 (`?userId=` 쿼리 파라미터) |
-| POST | `/api/reservations/{reservationId}/cancel` | 필요 (미적용) | 예약 취소 |
-
-> JWT 필터 적용 후 userId 직접 전달 방식 제거 예정 (`?userId=`, RequestBody userId 모두 제거)
+| POST | `/api/reservations/confirm` | 필요 (적용) | 예약 확정 |
+| GET | `/api/me/reservations` | 필요 (적용) | 내 예약 조회 (userId는 JWT Principal에서 추출) |
+| POST | `/api/reservations/{reservationId}/cancel` | 필요 (적용) | 예약 취소 |
 
 ---
 

--- a/src/main/java/com/demo/seatreservation/seat/controller/ReservationCancelController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/ReservationCancelController.java
@@ -3,6 +3,8 @@ package com.demo.seatreservation.seat.controller;
 import com.demo.seatreservation.common.ApiResponse;
 import com.demo.seatreservation.seat.dto.response.ReservationCancelResponse;
 import com.demo.seatreservation.seat.service.ReservationService;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,7 +17,10 @@ public class ReservationCancelController {
     }
 
     @PostMapping("/{reservationId}/cancel")
-    public ApiResponse<ReservationCancelResponse> cancel(@PathVariable Long reservationId, @RequestParam Long userId) {
-        return ApiResponse.ok(reservationService.cancel(reservationId, userId));
+    public ApiResponse<ReservationCancelResponse> cancel(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        return ApiResponse.ok(reservationService.cancel(reservationId, principal.getUserId()));
     }
 }

--- a/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
@@ -4,7 +4,9 @@ import com.demo.seatreservation.common.ApiResponse;
 import com.demo.seatreservation.seat.dto.request.ReservationConfirmRequest;
 import com.demo.seatreservation.seat.dto.response.ReservationConfirmResponse;
 import com.demo.seatreservation.seat.service.ReservationService;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,8 +20,9 @@ public class ReservationConfirmController {
 
     @PostMapping("/confirm")
     public ApiResponse<ReservationConfirmResponse> confirm(
-            @Valid @RequestBody ReservationConfirmRequest request
+            @Valid @RequestBody ReservationConfirmRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ApiResponse.ok(reservationService.confirm(request));
+        return ApiResponse.ok(reservationService.confirm(principal.getUserId(), request));
     }
 }

--- a/src/main/java/com/demo/seatreservation/seat/controller/ReservationQueryController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/ReservationQueryController.java
@@ -4,13 +4,12 @@ import com.demo.seatreservation.common.ApiResponse;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
 import com.demo.seatreservation.seat.dto.response.MyReservationResponse;
 import com.demo.seatreservation.seat.service.ReservationQueryService;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-/**
- * 내 예약 조회 API
- */
 @RestController
 @RequestMapping("/api/me")
 public class ReservationQueryController {
@@ -21,14 +20,13 @@ public class ReservationQueryController {
         this.reservationQueryService = reservationQueryService;
     }
 
-    // 내 예약 조회 (status 필터 선택 가능)
     @GetMapping("/reservations")
     public ApiResponse<List<MyReservationResponse>> getMyReservations(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestParam(required = false) ReservationStatus status
     ) {
         return ApiResponse.ok(
-                reservationQueryService.getMyReservations(userId, status)
+                reservationQueryService.getMyReservations(principal.getUserId(), status)
         );
     }
 }

--- a/src/main/java/com/demo/seatreservation/seat/controller/SeatHoldController.java
+++ b/src/main/java/com/demo/seatreservation/seat/controller/SeatHoldController.java
@@ -2,8 +2,10 @@ package com.demo.seatreservation.seat.controller;
 
 import com.demo.seatreservation.seat.dto.request.SeatHoldCancelRequest;
 import com.demo.seatreservation.seat.dto.response.SeatHoldCancelResponse;
+import com.demo.seatreservation.security.principal.CustomUserPrincipal;
 import jakarta.validation.Valid;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import com.demo.seatreservation.common.ApiResponse;
@@ -24,17 +26,19 @@ public class SeatHoldController {
     @PostMapping("/{seatId}/hold")
     public ApiResponse<SeatHoldResponse> hold(
             @PathVariable Long seatId,
-            @Valid @RequestBody SeatHoldRequest request
+            @Valid @RequestBody SeatHoldRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ApiResponse.ok(seatHoldService.hold(seatId, request));
+        return ApiResponse.ok(seatHoldService.hold(seatId, principal.getUserId(), request));
     }
 
     @DeleteMapping("/{seatId}/hold")
     public ApiResponse<SeatHoldCancelResponse> cancelHold(
             @PathVariable Long seatId,
-            @Valid @RequestBody SeatHoldCancelRequest request
+            @Valid @RequestBody SeatHoldCancelRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ApiResponse.ok(seatHoldService.cancelHold(seatId, request));
+        return ApiResponse.ok(seatHoldService.cancelHold(seatId, principal.getUserId(), request));
     }
 
 }

--- a/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
@@ -11,7 +11,4 @@ public class ReservationConfirmRequest {
 
     @NotNull
     private Long showId;
-
-    @NotNull
-    private Long userId;
 }

--- a/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldCancelRequest.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldCancelRequest.java
@@ -7,16 +7,9 @@ public class SeatHoldCancelRequest {
     @NotNull
     private Long showId;
 
-    @NotNull
-    private Long userId;
-
     public SeatHoldCancelRequest() {}
 
     public Long getShowId() {
         return showId;
-    }
-
-    public Long getUserId() {
-        return userId;
     }
 }

--- a/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldRequest.java
+++ b/src/main/java/com/demo/seatreservation/seat/dto/request/SeatHoldRequest.java
@@ -7,11 +7,7 @@ public class SeatHoldRequest {
     @NotNull
     private Long showId;
 
-    @NotNull
-    private Long userId; // 인증 전 임시
-
     public SeatHoldRequest() {}
 
     public Long getShowId() { return showId; }
-    public Long getUserId() { return userId; }
 }

--- a/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
@@ -28,11 +28,10 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationConfirmResponse confirm(ReservationConfirmRequest request) {
+    public ReservationConfirmResponse confirm(Long userId, ReservationConfirmRequest request) {
 
         Long seatId = request.getSeatId();
         Long showId = request.getShowId();
-        Long userId = request.getUserId();
 
         String holdKey = HoldKey.of(showId, seatId);
 

--- a/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
+++ b/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
@@ -31,9 +31,8 @@ public class SeatHoldService {
     }
 
     @Transactional(readOnly = true)
-    public SeatHoldResponse hold(Long seatId, SeatHoldRequest request) {
+    public SeatHoldResponse hold(Long seatId, Long userId, SeatHoldRequest request) {
         Long showId = request.getShowId();
-        Long userId = request.getUserId();
 
         // 1) DB에 이미 RESERVED 있으면 막기
         boolean alreadyReserved = reservationRepository
@@ -68,10 +67,9 @@ public class SeatHoldService {
     }
 
     @Transactional
-    public SeatHoldCancelResponse cancelHold(Long seatId, SeatHoldCancelRequest request) {
+    public SeatHoldCancelResponse cancelHold(Long seatId, Long userId, SeatHoldCancelRequest request) {
 
         Long showId = request.getShowId();
-        Long userId = request.getUserId();
 
         String key = HoldKey.of(showId, seatId);
         String userHoldKey = "hold:user:" + showId + ":" + userId;

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationCancelControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationCancelControllerTest.java
@@ -4,54 +4,91 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 public class ReservationCancelControllerTest {
-    @Autowired
-    MockMvc mockMvc;
-    @Autowired
-    ReservationRepository reservationRepository;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ReservationRepository reservationRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-
-        // 테스트 데이터 초기화
         reservationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private User saveUser(String email) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode("password1!"))
+                        .name("테스터")
+                        .phone("010-0000-0000")
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private String loginAndGetToken(String email) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"email": "%s", "password": "password1!"}
+                                        """.formatted(email))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get("data").get("accessToken").asText();
     }
 
     @Test
     void cancelReservation_success() throws Exception {
-
         // 테스트 목적:
         // 예약 취소 요청 시
         // 정상적으로 상태가 CANCELED로 변경되는지 확인
-
-        long userId = 100L;
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Reservation reservation = reservationRepository.save(
                 Reservation.builder()
                         .seatId(1L)
                         .showId(1L)
-                        .userId(userId)
+                        .userId(user.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
 
         mockMvc.perform(
                         post("/api/reservations/{id}/cancel", reservation.getId())
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -61,26 +98,25 @@ public class ReservationCancelControllerTest {
 
     @Test
     void cancelReservation_otherUser_returns403() throws Exception {
-
         // 테스트 목적:
         // 다른 사용자가 예약 취소를 시도하면
         // 403 NOT_RESERVATION_OWNER가 발생해야 한다
-
-        long ownerId = 100L;
-        long otherUserId = 999L;
+        User owner = saveUser("owner@test.com");
+        saveUser("other@test.com");
+        String otherToken = loginAndGetToken("other@test.com");
 
         Reservation reservation = reservationRepository.save(
                 Reservation.builder()
                         .seatId(1L)
                         .showId(1L)
-                        .userId(ownerId)
+                        .userId(owner.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
 
         mockMvc.perform(
                         post("/api/reservations/{id}/cancel", reservation.getId())
-                                .param("userId", String.valueOf(otherUserId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherToken)
                 )
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.errorCode").value("NOT_RESERVATION_OWNER"));
@@ -88,25 +124,24 @@ public class ReservationCancelControllerTest {
 
     @Test
     void cancelReservation_alreadyCanceled_returns409() throws Exception {
-
         // 테스트 목적:
         // 이미 취소된 예약을 다시 취소하면
         // 409 ALREADY_CANCELED가 발생해야 한다
-
-        long userId = 100L;
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Reservation reservation = reservationRepository.save(
                 Reservation.builder()
                         .seatId(1L)
                         .showId(1L)
-                        .userId(userId)
+                        .userId(user.getId())
                         .status(ReservationStatus.CANCELED)
                         .build()
         );
 
         mockMvc.perform(
                         post("/api/reservations/{id}/cancel", reservation.getId())
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 )
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("ALREADY_CANCELED"));
@@ -114,28 +149,24 @@ public class ReservationCancelControllerTest {
 
     @Test
     void cancelReservation_notFound_returns404() throws Exception {
-
         // 테스트 목적:
         // 존재하지 않는 reservationId로 취소 요청 시
         // 404 RESERVATION_NOT_FOUND가 발생해야 한다
-
-        long userId = 100L;
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         mockMvc.perform(
                         post("/api/reservations/{id}/cancel", 9999L)
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 )
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("RESERVATION_NOT_FOUND"));
     }
 
     @Test
-    void cancelReservation_missingUserId_returns400() throws Exception {
-
+    void cancelReservation_noAuthToken_returns401() throws Exception {
         // 테스트 목적:
-        // userId는 필수 파라미터이므로
-        // 누락 시 400 Bad Request가 발생해야 한다
-
+        // Authorization 헤더 없이 취소 요청 시 401이 발생해야 한다
         Reservation reservation = reservationRepository.save(
                 Reservation.builder()
                         .seatId(1L)
@@ -148,6 +179,6 @@ public class ReservationCancelControllerTest {
         mockMvc.perform(
                         post("/api/reservations/{id}/cancel", reservation.getId())
                 )
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
@@ -2,9 +2,12 @@ package com.demo.seatreservation.seat.controller;
 
 import com.demo.seatreservation.domain.Reservation;
 import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
 import com.demo.seatreservation.repository.SeatRepository;
+import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.seat.redis.HoldKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,8 +16,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -23,33 +32,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class ReservationConfirmControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
-
-    @Autowired
-    SeatRepository seatRepository;
-
-    @Autowired
-    ReservationRepository reservationRepository;
-
-    @Autowired
-    StringRedisTemplate redisTemplate;
+    @Autowired MockMvc mockMvc;
+    @Autowired SeatRepository seatRepository;
+    @Autowired ReservationRepository reservationRepository;
+    @Autowired StringRedisTemplate redisTemplate;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-
-        // 테스트 시작 전 DB 예약 데이터 초기화
         reservationRepository.deleteAll();
+        seatRepository.deleteAll();
+        userRepository.deleteAll();
 
-        // Redis 전체 초기화 (HOLD 데이터 제거)
         redisTemplate.getConnectionFactory()
                 .getConnection()
                 .flushAll();
 
-        // Seat 데이터 초기화
-        seatRepository.deleteAll();
-
-        // 테스트용 좌석 1개 생성
         seatRepository.save(
                 Seat.builder()
                         .showId(1L)
@@ -60,38 +60,64 @@ public class ReservationConfirmControllerTest {
         );
     }
 
+    private User saveUser(String email) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode("password1!"))
+                        .name("테스터")
+                        .phone("010-0000-0000")
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private String loginAndGetToken(String email) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"email": "%s", "password": "password1!"}
+                                        """.formatted(email))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get("data").get("accessToken").asText();
+    }
+
     @Test
     void confirm_success_shouldReserveSeat() throws Exception {
-
         // 테스트 목적:
         // 1) 정상적인 HOLD 상태에서 예약 확정 요청 시 200 OK 반환
         // 2) DB에 RESERVED 상태의 예약이 생성되는지 확인
         // 3) Redis HOLD 키가 삭제되는지 확인
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
         Long showId = 1L;
 
-        // Redis HOLD 생성 (사용자 100이 좌석 선점)
+        // Redis HOLD 생성 (실제 user ID로 선점)
         String key = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(key, "100");
+        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
 
-        // 예약 확정 요청
         mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {
-                          "seatId": %d,
-                          "showId": %d,
-                          "userId": 100
-                        }
-                        """.formatted(seatId, showId)))
+                                {
+                                  "seatId": %d,
+                                  "showId": %d
+                                }
+                                """.formatted(seatId, showId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("RESERVED"));
 
         // DB에 예약이 생성되었는지 확인
         Reservation reservation = reservationRepository.findAll().get(0);
-
         org.junit.jupiter.api.Assertions.assertEquals(ReservationStatus.RESERVED, reservation.getStatus());
 
         // Redis HOLD 삭제 확인
@@ -99,64 +125,64 @@ public class ReservationConfirmControllerTest {
         org.junit.jupiter.api.Assertions.assertNull(owner);
     }
 
-
     @Test
     void confirm_withoutHold_shouldReturn409() throws Exception {
-
         // 테스트 목적:
         // Redis에 HOLD 키가 존재하지 않는 상태에서
         // 예약 확정 요청 시 409 HOLD_EXPIRED 에러가 발생해야 한다
+        saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
 
         mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {
-                          "seatId": %d,
-                          "showId": 1,
-                          "userId": 100
-                        }
-                        """.formatted(seatId)))
+                                {
+                                  "seatId": %d,
+                                  "showId": 1
+                                }
+                                """.formatted(seatId)))
                 .andExpect(status().isConflict());
     }
 
-
     @Test
     void confirm_notOwner_shouldReturn403() throws Exception {
-
         // 테스트 목적:
         // HOLD를 건 사용자와 다른 userId가 예약 확정을 시도할 경우
         // 403 NOT_HOLD_OWNER 에러가 발생해야 한다
+        User user1 = saveUser("user1@test.com");
+        User user2 = saveUser("user2@test.com");
+        String token1 = loginAndGetToken("user1@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
         Long showId = 1L;
 
-        // Redis HOLD 생성 (user 200이 선점)
+        // user2가 선점한 HOLD
         String key = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(key, "200");
+        redisTemplate.opsForValue().set(key, String.valueOf(user2.getId()));
 
-        // user 100이 예약 확정 시도
+        // user1이 예약 확정 시도
         mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {
-                          "seatId": %d,
-                          "showId": %d,
-                          "userId": 100
-                        }
-                        """.formatted(seatId, showId)))
+                                {
+                                  "seatId": %d,
+                                  "showId": %d
+                                }
+                                """.formatted(seatId, showId)))
                 .andExpect(status().isForbidden());
     }
 
-
     @Test
     void confirm_twice_shouldReturnAlreadyReserved() throws Exception {
-
         // 테스트 목적:
         // 동일 좌석에 대해 예약 확정을 두 번 시도할 경우
-        // 두 번째 요청은 DB 유니크 제약 조건에 의해 409 ALREADY_RESERVED 에러가 발생해야 한다
-        // (사전 exists 체크를 통과하더라도, 최종적으로 DB가 중복을 방어하는지 검증)
+        // 두 번째 요청은 409 ALREADY_RESERVED 에러가 발생해야 한다
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
         Long showId = 1L;
@@ -164,33 +190,33 @@ public class ReservationConfirmControllerTest {
         String key = HoldKey.of(showId, seatId);
 
         // 첫 번째 HOLD 생성
-        redisTemplate.opsForValue().set(key, "100");
+        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
 
         // 첫 번째 confirm (성공)
         mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {
-                          "seatId": %d,
-                          "showId": %d,
-                          "userId": 100
-                        }
-                        """.formatted(seatId, showId)))
+                                {
+                                  "seatId": %d,
+                                  "showId": %d
+                                }
+                                """.formatted(seatId, showId)))
                 .andExpect(status().isOk());
 
         // 두 번째 confirm을 위해 다시 HOLD 생성
-        redisTemplate.opsForValue().set(key, "100");
+        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
 
         // 두 번째 confirm (이미 예약됨 → 실패)
         mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {
-                          "seatId": %d,
-                          "showId": %d,
-                          "userId": 100
-                        }
-                        """.formatted(seatId, showId)))
+                                {
+                                  "seatId": %d,
+                                  "showId": %d
+                                }
+                                """.formatted(seatId, showId)))
                 .andExpect(status().isConflict());
     }
 
@@ -198,14 +224,14 @@ public class ReservationConfirmControllerTest {
     void confirm_whenAlreadyReservedExists_shouldReturnAlreadyReserved() throws Exception {
         // 테스트 목적:
         // 이미 DB에 RESERVED 상태의 예약이 존재하는 경우
-        // confirm 요청 시 save까지 가지 않고
         // existsBy... 사전 체크에서 바로 중복을 감지하여 실패해야 한다
-        // (비즈니스 로직 레벨에서 중복을 1차적으로 차단하는지 검증)
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
         Long showId = 1L;
 
-        // 1. DB에 이미 RESERVED 예약 존재
+        // DB에 이미 RESERVED 예약 존재
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId)
@@ -215,21 +241,37 @@ public class ReservationConfirmControllerTest {
                         .build()
         );
 
-        // 2. Redis HOLD는 현재 요청 사용자 것으로 생성
+        // Redis HOLD는 현재 요청 사용자 것으로 생성
         String holdKey = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(holdKey, "100");
+        redisTemplate.opsForValue().set(holdKey, String.valueOf(user.getId()));
 
-        // 3. confirm 요청 -> exists() 에서 바로 ALREADY_RESERVED
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "seatId": %d,
+                                  "showId": %d
+                                }
+                                """.formatted(seatId, showId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("ALREADY_RESERVED"));
+    }
+
+    @Test
+    void confirm_noAuthToken_returns401() throws Exception {
+        // 테스트 목적:
+        // Authorization 헤더 없이 confirm 요청 시 401이 발생해야 한다
+        Long seatId = seatRepository.findAll().get(0).getId();
+
         mockMvc.perform(post("/api/reservations/confirm")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                    {
-                      "seatId": %d,
-                      "showId": %d,
-                      "userId": 100
-                    }
-                    """.formatted(seatId, showId)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.errorCode").value("ALREADY_RESERVED"));
+                                {
+                                  "seatId": %d,
+                                  "showId": 1
+                                }
+                                """.formatted(seatId)))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/ReservationQueryControllerTest.java
@@ -1,20 +1,31 @@
 package com.demo.seatreservation.seat.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.demo.seatreservation.domain.Reservation;
 import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
 import com.demo.seatreservation.repository.SeatRepository;
+import com.demo.seatreservation.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,15 +34,16 @@ class ReservationQueryControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ReservationRepository reservationRepository;
     @Autowired SeatRepository seatRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-
-        // 테스트 데이터 초기화
         reservationRepository.deleteAll();
         seatRepository.deleteAll();
+        userRepository.deleteAll();
 
-        // 좌석 2개 생성 (UNIQUE 충돌 방지)
         seatRepository.save(
                 Seat.builder()
                         .showId(1L)
@@ -51,29 +63,55 @@ class ReservationQueryControllerTest {
         );
     }
 
+    private User saveUser(String email) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode("password1!"))
+                        .name("테스터")
+                        .phone("010-0000-0000")
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private String loginAndGetToken(String email) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"email": "%s", "password": "password1!"}
+                                        """.formatted(email))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get("data").get("accessToken").asText();
+    }
+
     @Test
     void getMyReservations_returnsUserReservations() throws Exception {
-
         // 테스트 목적:
-        // 특정 userId로 예약 조회 시
-        // 해당 사용자의 예약 목록이 정상적으로 반환되는지 확인
+        // 로그인한 사용자의 예약 목록이 정상적으로 반환되는지 확인
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Long seatId = seatRepository.findAll().get(0).getId();
         long showId = 1L;
-        long userId = 100L;
 
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId)
                         .showId(showId)
-                        .userId(userId)
+                        .userId(user.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
 
         mockMvc.perform(
                         get("/api/me/reservations")
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -84,23 +122,21 @@ class ReservationQueryControllerTest {
 
     @Test
     void getMyReservations_withStatusFilter_returnsFilteredReservations() throws Exception {
-
         // 테스트 목적:
-        // status 필터가 있을 경우
-        // 해당 상태의 예약만 조회되는지 확인
+        // status 필터가 있을 경우 해당 상태의 예약만 조회되는지 확인
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Long seatId1 = seatRepository.findAll().get(0).getId();
         Long seatId2 = seatRepository.findAll().get(1).getId();
-
         long showId = 1L;
-        long userId = 100L;
 
         // RESERVED 예약
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId1)
                         .showId(showId)
-                        .userId(userId)
+                        .userId(user.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
@@ -110,33 +146,32 @@ class ReservationQueryControllerTest {
                 Reservation.builder()
                         .seatId(seatId2)
                         .showId(showId)
-                        .userId(userId)
+                        .userId(user.getId())
                         .status(ReservationStatus.CANCELED)
                         .build()
         );
 
         mockMvc.perform(
                         get("/api/me/reservations")
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .param("status", "RESERVED")
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].status").value("RESERVED"));
     }
 
     @Test
     void getMyReservations_emptyResult_returnsEmptyList() throws Exception {
-
         // 테스트 목적:
-        // 해당 userId의 예약이 없을 경우
-        // 빈 리스트가 반환되는지 확인
-
-        long userId = 999L;
+        // 해당 사용자의 예약이 없을 경우 빈 리스트가 반환되는지 확인
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         mockMvc.perform(
                         get("/api/me/reservations")
-                                .param("userId", String.valueOf(userId))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -145,55 +180,51 @@ class ReservationQueryControllerTest {
     }
 
     @Test
-    void getMyReservations_missingUserId_returns400() throws Exception {
-
+    void getMyReservations_noAuthToken_returns401() throws Exception {
         // 테스트 목적:
-        // userId는 필수 파라미터이므로
-        // 누락 시 400 Bad Request가 발생해야 한다
-
+        // Authorization 헤더 없이 요청 시 401이 발생해야 한다
         mockMvc.perform(
                         get("/api/me/reservations")
                 )
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
     void getMyReservations_excludesOtherUsersReservations() throws Exception {
-
         // 테스트 목적:
         // 다른 사용자의 예약은 조회되지 않아야 한다
+        User user1 = saveUser("user1@test.com");
+        User user2 = saveUser("user2@test.com");
+        String token1 = loginAndGetToken("user1@test.com");
 
         Long seatId1 = seatRepository.findAll().get(0).getId();
         Long seatId2 = seatRepository.findAll().get(1).getId();
-
         long showId = 1L;
 
-        long userId1 = 100L;
-        long userId2 = 200L;
-
-        // userId=100 예약
+        // user1 예약
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId1)
                         .showId(showId)
-                        .userId(userId1)
+                        .userId(user1.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
 
-        // userId=200 예약
+        // user2 예약
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId2)
                         .showId(showId)
-                        .userId(userId2)
+                        .userId(user2.getId())
                         .status(ReservationStatus.RESERVED)
                         .build()
         );
 
+        // user1 토큰으로 조회 → user1의 예약만 반환
         mockMvc.perform(
                         get("/api/me/reservations")
-                                .param("userId", String.valueOf(userId1))
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))

--- a/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
+++ b/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
@@ -9,8 +9,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import com.demo.seatreservation.domain.Reservation;
+import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
+import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.seat.redis.HoldKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,11 +22,17 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import com.demo.seatreservation.domain.Seat;
 import com.demo.seatreservation.repository.SeatRepository;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -33,19 +42,48 @@ class SeatHoldControllerTest {
     @Autowired StringRedisTemplate stringRedisTemplate;
     @Autowired SeatRepository seatRepository;
     @Autowired ReservationRepository reservationRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
         reservationRepository.deleteAll();
         seatRepository.deleteAll();
+        userRepository.deleteAll();
 
-        // Redis 전체 초기화
         stringRedisTemplate.getConnectionFactory()
                 .getConnection()
                 .flushAll();
     }
 
-    // 공통 좌석 생성
+    private User saveUser(String email) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode("password1!"))
+                        .name("테스터")
+                        .phone("010-0000-0000")
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private String loginAndGetToken(String email) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"email": "%s", "password": "password1!"}
+                                        """.formatted(email))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get("data").get("accessToken").asText();
+    }
+
     private Seat createSeat(Long showId, int number) {
         return seatRepository.save(
                 Seat.builder()
@@ -57,7 +95,6 @@ class SeatHoldControllerTest {
         );
     }
 
-    // 여러 좌석 생성 + 순서 보장
     private List<Seat> createSeats(Long showId, int count) {
         return IntStream.rangeClosed(1, count)
                 .mapToObj(i -> createSeat(showId, i))
@@ -70,22 +107,22 @@ class SeatHoldControllerTest {
         // 1) hold 요청이 성공(200)하는지
         // 2) 응답 JSON이 성공 형태로 내려오는지
         // 3) Redis에 hold 키가 생성되고 TTL이 설정되는지(선점이 실제로 걸렸는지)
+        User user = saveUser("hold@test.com");
+        String token = loginAndGetToken("hold@test.com");
+
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
-        long userId = 100L;
 
         String key = HoldKey.of(showId, seatId);
 
         mockMvc.perform(
                         post("/api/seats/{seatId}/hold", seatId)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
-                                {
-                                  "showId": %d,
-                                  "userId": %d
-                                }
-                                """.formatted(showId, userId))
+                                        {"showId": %d}
+                                        """.formatted(showId))
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -94,13 +131,29 @@ class SeatHoldControllerTest {
                 .andExpect(jsonPath("$.data.status").value("HELD"))
                 .andExpect(jsonPath("$.data.expiresInSec").isNumber());
 
-        // Redis 키 생성 확인
         String owner = stringRedisTemplate.opsForValue().get(key);
         Long ttl = stringRedisTemplate.getExpire(key, TimeUnit.SECONDS);
 
-        org.junit.jupiter.api.Assertions.assertEquals(String.valueOf(userId), owner);
+        org.junit.jupiter.api.Assertions.assertEquals(String.valueOf(user.getId()), owner);
         org.junit.jupiter.api.Assertions.assertNotNull(ttl);
         org.junit.jupiter.api.Assertions.assertTrue(ttl > 0 && ttl <= 300);
+    }
+
+    @Test
+    void hold_noAuthToken_returns401() throws Exception {
+        // 테스트 목적:
+        // Authorization 헤더 없이 hold 요청 시 401이 발생해야 한다
+        Seat seat = createSeat(1L, 1);
+        Long seatId = seat.getId();
+
+        mockMvc.perform(
+                        post("/api/seats/{seatId}/hold", seatId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"showId": 1}
+                                        """)
+                )
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -108,26 +161,33 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // 이미 선점된 좌석을 다른 사용자가 다시 hold하려고 하면
         // 409 Conflict로 막히는지(= SEAT_ALREADY_HELD 케이스)
+        saveUser("user1@test.com");
+        saveUser("user2@test.com");
+        String token1 = loginAndGetToken("user1@test.com");
+        String token2 = loginAndGetToken("user2@test.com");
+
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
-        // 1차 hold (성공)
+        // 1차 hold (user1 성공)
         mockMvc.perform(
                 post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"showId": %d, "userId": 100}
+                                {"showId": %d}
                                 """.formatted(showId))
         ).andExpect(status().isOk());
 
-        // 2차 hold (다른 사용자) -> 충돌(409)
+        // 2차 hold (user2 → 충돌 409)
         mockMvc.perform(
                         post("/api/seats/{seatId}/hold", seatId)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
-                                {"showId": %d, "userId": 200}
-                                """.formatted(showId))
+                                        {"showId": %d}
+                                        """.formatted(showId))
                 )
                 .andExpect(status().isConflict());
     }
@@ -136,31 +196,38 @@ class SeatHoldControllerTest {
     void hold_afterTtlExpired_canHoldAgain() throws Exception {
         // 테스트 목적:
         // TTL이 만료되면 선점 키가 사라지고
-        // 같은 좌석을 다시 hold 할 수 있어야 한다(재선점 가능)
+        // 다른 사용자가 같은 좌석을 다시 hold 할 수 있어야 한다
+        saveUser("user1@test.com");
+        saveUser("user2@test.com");
+        String token1 = loginAndGetToken("user1@test.com");
+        String token2 = loginAndGetToken("user2@test.com");
+
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
         String key = HoldKey.of(showId, seatId);
 
-        // 1차 hold 성공
+        // user1 1차 hold 성공
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                {"showId": %d, "userId": 100}
-            """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
         // TTL을 테스트용으로 1초로 줄여서 만료시키기
         stringRedisTemplate.expire(key, 1, TimeUnit.SECONDS);
         Thread.sleep(1500);
 
-        // 만료 후 다시 hold -> 성공해야 정상
+        // user2 만료 후 다시 hold → 성공해야 정상
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                {"showId": %d, "userId": 200}
-            """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
     }
@@ -170,11 +237,13 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // DB에 이미 RESERVED 상태의 예약이 있으면
         // hold 요청을 거절해야 한다(= ALREADY_RESERVED 케이스)
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
+
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
-        // 1. DB에 RESERVED 예약 데이터 미리 넣기
         reservationRepository.save(
                 Reservation.builder()
                         .showId(showId)
@@ -184,12 +253,12 @@ class SeatHoldControllerTest {
                         .build()
         );
 
-        // 2. hold 요청 보내기
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": 100}
-                    """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isConflict());
     }
 
@@ -197,25 +266,16 @@ class SeatHoldControllerTest {
     void hold_missingShowId_returns400() throws Exception {
         // 테스트 목적:
         // showId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
+
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"userId\": 100}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void hold_missingUserId_returns400() throws Exception {
-        // 테스트 목적:
-        // userId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
-        Seat seat = createSeat(1L, 1);
-        Long seatId = seat.getId();
-
-        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"showId\": 1}"))
+                        .content("{}"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -224,28 +284,31 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // 1) 정상적인 hold 취소 요청 시 200 OK 반환
         // 2) Redis hold 키가 삭제되는지 확인
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
-        long userId = 100L;
 
         String key = HoldKey.of(showId, seatId);
 
         // 먼저 hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": %d}
-                    """.formatted(showId, userId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
         // hold 취소 요청
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": %d}
-                    """.formatted(showId, userId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("AVAILABLE"));
@@ -260,29 +323,31 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // HOLD를 건 사용자와 다른 userId가 취소하려 하면
         // 403 NOT_HOLD_OWNER가 발생해야 한다
+        saveUser("user1@test.com");
+        saveUser("user2@test.com");
+        String token1 = loginAndGetToken("user1@test.com");
+        String token2 = loginAndGetToken("user2@test.com");
 
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
-        //String key = "hold:" + showId + ":" + seatId;
-        String key = HoldKey.of(showId, seatId);
-        stringRedisTemplate.delete(key);
-
-        // user 100이 hold
+        // user1이 hold
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": 100}
-                    """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // user 200이 취소 시도
+        // user2가 취소 시도
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": 200}
-                    """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isForbidden());
     }
 
@@ -291,6 +356,8 @@ class SeatHoldControllerTest {
         // 테스트 목적:
         // HOLD가 이미 만료되었거나 존재하지 않을 때
         // 409 HOLD_EXPIRED가 발생해야 한다
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
@@ -300,10 +367,11 @@ class SeatHoldControllerTest {
 
         // hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": 100}
-                    """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
         // TTL 강제 만료
@@ -312,34 +380,35 @@ class SeatHoldControllerTest {
 
         // 취소 시도
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                        {"showId": %d, "userId": 100}
-                    """.formatted(showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isConflict());
     }
 
     @Test
     void hold_exceedsLimit_returns409() throws Exception {
-
         // 테스트 목적:
         // 한 사용자가 4개까지는 HOLD 가능하지만
         // 5번째 HOLD 시도는 409 HOLD_LIMIT_EXCEEDED 발생해야 한다
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         long showId = 1L;
-        long userId = 100L;
-
-        List<Seat> seats = createSeats(1L, 5);
+        List<Seat> seats = createSeats(showId, 5);
 
         // 1~4번 좌석 HOLD 성공
         for (int i = 0; i < 4; i++) {
             Long seatId = seats.get(i).getId();
 
             mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                        {"showId": %d, "userId": %d}
-                        """.formatted(showId, userId)))
+                                    {"showId": %d}
+                                    """.formatted(showId)))
                     .andExpect(status().isOk());
         }
 
@@ -347,34 +416,35 @@ class SeatHoldControllerTest {
         Long seatId5 = seats.get(4).getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId5)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                    {"showId": %d, "userId": %d}
-                    """.formatted(showId, userId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isConflict());
     }
 
     @Test
     void hold_afterCancel_canHoldAgain() throws Exception {
-
         // 테스트 목적:
         // 4개 HOLD 상태에서 하나 cancel 하면
         // 다시 HOLD가 가능해야 한다
+        saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
 
         long showId = 1L;
-        long userId = 100L;
-
-        List<Seat> seats = createSeats(1L, 5);
+        List<Seat> seats = createSeats(showId, 5);
 
         // 4개 HOLD
         for (int i = 0; i < 4; i++) {
             Long seatId = seats.get(i).getId();
 
             mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                        {"showId": %d, "userId": %d}
-                        """.formatted(showId, userId)))
+                                    {"showId": %d}
+                                    """.formatted(showId)))
                     .andExpect(status().isOk());
         }
 
@@ -382,20 +452,22 @@ class SeatHoldControllerTest {
         Long cancelSeatId = seats.get(0).getId();
 
         mockMvc.perform(delete("/api/seats/{seatId}/hold", cancelSeatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                    {"showId": %d, "userId": %d}
-                    """.formatted(showId, userId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
         // 다시 HOLD → 성공해야 정상
         Long newSeatId = seats.get(4).getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", newSeatId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                    {"showId": %d, "userId": %d}
-                    """.formatted(showId, userId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 작업 내용
보호 API에서 클라이언트가 request body/query parameter 등으로 직접 전달하던 `userId`를 제거하고,  
JWT 인증 결과로 생성된 `@AuthenticationPrincipal CustomUserPrincipal` 기반으로 현재 로그인 사용자의 `userId`를 사용하도록 리팩토링

기존에는 일부 보호 API가 `userId`를 클라이언트 입력값으로 직접 받고 있어,  
악의적인 사용자가 다른 사용자의 `userId`를 조작해 요청할 수 있는 위험이 있었음.

이번 변경으로 보호 API의 사용자 식별은 request 값이 아니라,  
JWT 인증 후 `SecurityContext`에 저장된 인증 사용자 정보 기반으로 처리됨.

자세한 내용은 이슈 #49 확인