### PR TITLE
[feat/frontend-seat-query] 좌석 조회 화면 구현 및 개발용 초기 데이터 추가 (#63)

### DIFF
--- a/backend/src/main/java/com/demo/seatreservation/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/demo/seatreservation/global/config/DataInitializer.java
@@ -1,0 +1,46 @@
+package com.demo.seatreservation.global.config;
+
+import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final SeatRepository seatRepository;
+
+    @Override
+    public void run(String... args) {
+        if (seatRepository.count() > 0) {
+            return;
+        }
+
+        List<Seat> seats = new ArrayList<>();
+        long showId = 1L;
+
+        String[] zones = {"A", "B", "C"};
+        int rows = 4;
+        int seatsPerRow = 8;
+
+        for (String zone : zones) {
+            for (int row = 1; row <= rows; row++) {
+                for (int number = 1; number <= seatsPerRow; number++) {
+                    seats.add(Seat.builder()
+                            .showId(showId)
+                            .zone(zone)
+                            .row(row)
+                            .number(number)
+                            .build());
+                }
+            }
+        }
+
+        seatRepository.saveAll(seats);
+    }
+}

--- a/frontend/src/api/seat.api.ts
+++ b/frontend/src/api/seat.api.ts
@@ -1,0 +1,10 @@
+import { axiosInstance } from '@/lib/axios';
+import type { ApiResponse } from '@/types/api.types';
+import type { Seat } from '@/entities/seat';
+
+export async function getSeatsApi(showId: number): Promise<Seat[]> {
+  const { data } = await axiosInstance.get<ApiResponse<Seat[]>>('/api/seats', {
+    params: { showId },
+  });
+  return data.data;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,65 +1,16 @@
-import Image from "next/image";
+import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
+    <main className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4">
+      <h1 className="mb-2 text-2xl font-semibold text-zinc-900">좌석 예매</h1>
+      <p className="mb-8 text-sm text-zinc-500">공연을 선택해 좌석을 예매하세요.</p>
+      <Link
+        href="/shows/1/seats"
+        className="rounded-md bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
+      >
+        공연 입장
+      </Link>
+    </main>
   );
 }

--- a/frontend/src/app/shows/[showId]/seats/page.tsx
+++ b/frontend/src/app/shows/[showId]/seats/page.tsx
@@ -1,0 +1,10 @@
+import { SeatsView } from '@/features/seat/components/SeatsView';
+
+interface Props {
+  params: Promise<{ showId: string }>;
+}
+
+export default async function SeatsPage({ params }: Props) {
+  const { showId } = await params;
+  return <SeatsView showId={Number(showId)} />;
+}

--- a/frontend/src/entities/seat.ts
+++ b/frontend/src/entities/seat.ts
@@ -1,0 +1,9 @@
+export type SeatStatus = 'AVAILABLE' | 'HELD' | 'RESERVED';
+
+export interface Seat {
+  seatId: number;
+  zone: string;
+  row: number;
+  number: number;
+  status: SeatStatus;
+}

--- a/frontend/src/features/seat/components/SeatCard.tsx
+++ b/frontend/src/features/seat/components/SeatCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { Seat, SeatStatus } from '@/entities/seat';
+
+const statusStyle: Record<SeatStatus, { className: string; disabled: boolean }> = {
+  AVAILABLE: {
+    className:
+      'border-green-400 bg-green-100 text-green-800 hover:bg-green-200 cursor-pointer',
+    disabled: false,
+  },
+  HELD: {
+    className: 'border-zinc-200 bg-zinc-100 text-zinc-400 cursor-not-allowed',
+    disabled: true,
+  },
+  RESERVED: {
+    className: 'border-zinc-200 bg-zinc-100 text-zinc-400 cursor-not-allowed',
+    disabled: true,
+  },
+};
+
+interface SeatCardProps {
+  seat: Seat;
+  onClick?: (seat: Seat) => void;
+}
+
+export function SeatCard({ seat, onClick }: SeatCardProps) {
+  const { className, disabled } = statusStyle[seat.status];
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onClick?.(seat)}
+      className={`flex h-9 w-9 items-center justify-center rounded border text-xs font-medium transition-colors ${className}`}
+    >
+      {seat.number}
+    </button>
+  );
+}

--- a/frontend/src/features/seat/components/SeatGrid.tsx
+++ b/frontend/src/features/seat/components/SeatGrid.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { Seat } from '@/entities/seat';
+import { SeatCard } from './SeatCard';
+
+interface SeatGridProps {
+  seats: Seat[];
+  onSeatClick?: (seat: Seat) => void;
+}
+
+export function SeatGrid({ seats, onSeatClick }: SeatGridProps) {
+  const byZone = seats.reduce<Record<string, Seat[]>>((acc, seat) => {
+    (acc[seat.zone] ??= []).push(seat);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-8">
+      {Object.keys(byZone)
+        .sort()
+        .map((zone) => {
+          const byRow = byZone[zone].reduce<Record<number, Seat[]>>((acc, seat) => {
+            (acc[seat.row] ??= []).push(seat);
+            return acc;
+          }, {});
+
+          return (
+            <section key={zone}>
+              <h2 className="mb-3 text-sm font-semibold text-zinc-700">{zone} 구역</h2>
+              <div className="space-y-1.5">
+                {Object.keys(byRow)
+                  .sort((a, b) => Number(a) - Number(b))
+                  .map((row) => (
+                    <div key={row} className="flex items-center gap-1.5">
+                      <span className="w-5 shrink-0 text-right text-[11px] text-zinc-400">
+                        {row}
+                      </span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {byRow[Number(row)]
+                          .sort((a, b) => a.number - b.number)
+                          .map((seat) => (
+                            <SeatCard key={seat.seatId} seat={seat} onClick={onSeatClick} />
+                          ))}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            </section>
+          );
+        })}
+    </div>
+  );
+}

--- a/frontend/src/features/seat/components/SeatsView.tsx
+++ b/frontend/src/features/seat/components/SeatsView.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useSeats } from '@/features/seat/hooks/useSeats';
+import { SeatGrid } from './SeatGrid';
+
+interface SeatsViewProps {
+  showId: number;
+}
+
+export function SeatsView({ showId }: SeatsViewProps) {
+  const { data: seats, isLoading, isError } = useSeats(showId);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-zinc-500">
+        좌석 불러오는 중...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-red-500">
+        좌석 정보를 불러오지 못했습니다.
+      </div>
+    );
+  }
+
+  if (!seats?.length) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-zinc-500">
+        등록된 좌석이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-1 text-xl font-semibold text-zinc-900">좌석 선택</h1>
+      <p className="mb-6 text-xs text-zinc-400">5초마다 자동으로 갱신됩니다.</p>
+
+      <div className="mb-6 flex gap-5 text-xs text-zinc-600">
+        <span className="flex items-center gap-1.5">
+          <span className="h-3.5 w-3.5 rounded border border-green-400 bg-green-100" />
+          선택 가능
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-3.5 w-3.5 rounded border border-zinc-200 bg-zinc-100" />
+          선택 불가
+        </span>
+      </div>
+
+      <SeatGrid seats={seats} />
+    </main>
+  );
+}

--- a/frontend/src/features/seat/hooks/useSeats.ts
+++ b/frontend/src/features/seat/hooks/useSeats.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getSeatsApi } from '@/api/seat.api';
+
+export function useSeats(showId: number) {
+  return useQuery({
+    queryKey: ['seats', showId],
+    queryFn: () => getSeatsApi(showId),
+    refetchInterval: 5000,
+    staleTime: 0,
+  });
+}


### PR DESCRIPTION
- GET /api/seats?showId= API 연동 및 Seat 도메인 타입 정의
  - useSeats 훅에서 5초 폴링으로 다른 사용자의 선점·예약 상태 자동 반영
  - SeatCard, SeatGrid, SeatsView 컴포넌트 구현 (zone → row 2단계 그룹핑)
  - /shows/[showId]/seats 동적 라우트 페이지 추가
  - DataInitializer로 앱 시작 시 개발용 초기 좌석 96석 자동 삽입

자세한 내용은 이슈 #63  확인