### PR TITLE
[security/refresh-token-reuse-detection] Refresh Token 탈취 감지 및 전체 세션 종료 구현 (#66)

### DIFF
--- a/backend/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
+++ b/backend/src/main/java/com/demo/seatreservation/auth/CLAUDE.md
@@ -35,13 +35,15 @@
 ## Redis 세션 구조
 
 ```
-refresh:{userId}:{sessionId}    = refreshToken    (TTL 14일)
-refresh:token:{refreshToken}    = userId:sessionId
-refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
+refresh:{userId}:{sessionId}    = refreshToken              (TTL 14일)
+refresh:token:{refreshToken}    = userId:sessionId          (정상)
+refresh:token:{oldRefreshToken} = ROTATED:userId:sessionId  (rotate 후 5분간 유지)
+refresh:sessions:{userId}       = Set<sessionId>            (전체 세션 목록)
 ```
 
 - 로그인마다 고유한 `sessionId` 생성 → 다중 기기 로그인 허용
 - `refresh:sessions:{userId}` Set으로 전체 세션 목록 추적
+- Rotation 시 이전 역조회 키는 삭제하지 않고 `"ROTATED:{userId}:{sessionId}"` 값으로 5분간 유지
 - 키 구조 변경 금지 — logout-all 등 세션 전체 조회에 의존
 
 ---
@@ -60,14 +62,15 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 
 ### Refresh (`/api/auth/refresh`)
 1. 쿠키에 refreshToken 없으면 → `UNAUTHORIZED`
-2. Redis에서 `refresh:token:{refreshToken}` 역조회 — 없으면 `INVALID_REFRESH_TOKEN`
-3. 역조회 결과(`userId:sessionId`)를 파싱
-4. Redis에서 `refresh:{userId}:{sessionId}` 조회
-5. 저장값과 요청값 비교 — 불일치 시 해당 세션 데이터 삭제 + sessionId Set에서 제거 + `INVALID_REFRESH_TOKEN`
-6. 새 Access Token 발급
-7. 새 Refresh Token 발급 (Rotation)
-8. 기존 역조회 키 삭제 후 Redis 저장값 갱신 (기존 토큰 즉시 무효화)
-9. sessionId는 유지
+2. Redis에서 `refresh:token:{refreshToken}` 역조회 — 없으면 → `INVALID_REFRESH_TOKEN`
+3. 역조회 결과가 `"ROTATED:..."` 로 시작하면 → 탈취 확정, `logoutAll()` 호출 후 `INVALID_REFRESH_TOKEN`
+4. 역조회 결과(`userId:sessionId`)를 파싱
+5. Redis에서 `refresh:{userId}:{sessionId}` 조회
+6. 저장값과 요청값 비교 — 불일치 시 탈취 확정, `logoutAll()` 호출 후 `INVALID_REFRESH_TOKEN`
+7. 새 Access Token 발급
+8. 새 Refresh Token 발급 (Rotation)
+9. 기존 역조회 키를 `"ROTATED:{userId}:{sessionId}"` 값으로 덮어쓰기 (TTL 5분)
+10. 새 역조회 키 + 새 본체 값 저장, sessionId는 유지
 
 ### Logout (`/api/auth/logout`) 
 1. Access Token 검증 (유효한 토큰 없으면 401 — 만료 시 먼저 refresh 필요)
@@ -91,9 +94,13 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 
 ## 보안 정책
 
-- Refresh Token 불일치 감지 시 → 해당 세션 즉시 삭제 (토큰 탈취 의심 처리)
+- **탈취 감지 시 `logoutAll()` 호출** — 해당 세션 하나가 아니라 해당 유저의 전체 세션 종료
+- 탈취 감지 경로 두 가지:
+  - ROTATED 마킹된 토큰 재사용 (공격자가 먼저 rotate 후 피해자가 이전 토큰 재시도)
+  - 역조회 키는 있는데 본체 값이 다른 경우 (동시성 이슈 or 위조)
 - `POST /api/auth/refresh`는 쿠키 기반 — SameSite=Strict, Path 제한으로 CSRF 방어
 - logout은 유효한 Access Token이 있을 때만 가능, 만료 시 클라이언트에서 토큰만 삭제하거나 refresh 후 logout
+- 프론트엔드: refresh 실패 시 에러 코드(`INVALID_REFRESH_TOKEN`)를 확인해 `/login?reason=security` 로 이동 → 보안 안내 메시지 표시
 
 ---
 
@@ -103,7 +110,7 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 |------|------|------|
 | `EMAIL_DUPLICATED` | 409 | 이미 가입된 이메일 |
 | `INVALID_CREDENTIALS` | 401 | 이메일 없음 또는 비밀번호 불일치 |
-| `INVALID_REFRESH_TOKEN` | 401 | Redis 없음 또는 불일치 |
+| `INVALID_REFRESH_TOKEN` | 401 | Redis 없음, ROTATED 재사용, 또는 본체 불일치 — 탈취 감지 시 `logoutAll()` 포함 |
 | `UNAUTHORIZED` | 401 | 쿠키 없음 또는 Access Token 없음/만료 |
 
 ---
@@ -127,9 +134,11 @@ refresh:sessions:{userId}       = Set<sessionId>  (전체 세션 목록)
 
 **Refresh**
 - 성공 시 access/refresh 모두 새로 발급
-- 이전 refresh token 재사용 시 실패
+- 성공 후 이전 역조회 키가 `"ROTATED:..."` 로 마킹되는지 확인
+- 이전 refresh token 재사용(ROTATED 감지) → `logoutAll()` 호출 → 전체 세션 삭제 후 401
+- ROTATED 재사용 시 다른 기기 세션까지 모두 종료되는지 확인
 - 쿠키 없으면 401
-- Redis 값 불일치 → 해당 세션 삭제 후 401
+- Redis 값 불일치(본체 mismatch) → `logoutAll()` 호출 → 전체 세션 삭제 후 401
 - A 기기 logout 후 B 기기 refresh는 여전히 성공
 
 **Logout**

--- a/backend/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
+++ b/backend/src/main/java/com/demo/seatreservation/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,6 +23,7 @@ import java.util.UUID;
 
 import java.security.SecureRandom;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -170,6 +172,16 @@ public class AuthService {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        // 이미 rotate된 토큰을 재사용한 경우 → 탈취 확정, 전체 세션 종료
+        if (refreshMetadata.startsWith("ROTATED:")) {
+            String rawMetadata = refreshMetadata.substring("ROTATED:".length());
+            RefreshTokenContext rotatedContext = parseRefreshMetadata(rawMetadata);
+            log.warn("[Security] Rotated token reuse detected. userId={}, sessionId={}",
+                    rotatedContext.userId(), rotatedContext.sessionId());
+            logoutAll(rotatedContext.userId());
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
         // refreshMetadata 형식: "userId:sessionId"
         RefreshTokenContext context = parseRefreshMetadata(refreshMetadata);
         Long userId = context.userId();
@@ -181,9 +193,10 @@ public class AuthService {
         // Redis에 저장된 실제 refresh token과 비교
         String storedToken = stringRedisTemplate.opsForValue().get(refreshKey);
 
-        // 값이 다르면 탈취 또는 위조 가능성으로 처리
+        // 역조회 키는 있는데 본체 값이 다름 → 탈취 확정, 전체 세션 종료
         if (storedToken == null || !storedToken.equals(refreshToken)) {
-            deleteRefreshSession(refreshKey, refreshLookupKey, sessionSetKey, sessionId);
+            log.warn("[Security] Refresh token mismatch detected. userId={}, sessionId={}", userId, sessionId);
+            logoutAll(userId);
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
@@ -193,8 +206,10 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.generateAccessToken(user, sessionId);
         String newRefreshToken = generateOpaqueRefreshToken();
 
-        // 기존 토큰 삭제 후 새 토큰 저장 (rotation)
-        stringRedisTemplate.delete(refreshLookupKey);
+        // 기존 역조회 키를 ROTATED 마킹으로 대체 (5분 유지)
+        // → 피해자가 이 토큰으로 재시도 시 탈취 감지 가능
+        stringRedisTemplate.opsForValue()
+                .set(refreshLookupKey, "ROTATED:" + userId + ":" + sessionId, Duration.ofMinutes(5));
         saveRefreshToken(userId, sessionId, newRefreshToken);
 
         // access token만 응답 body로 내려주기 위한 DTO

--- a/backend/src/test/java/com/demo/seatreservation/auth/controller/AuthRefreshControllerTest.java
+++ b/backend/src/test/java/com/demo/seatreservation/auth/controller/AuthRefreshControllerTest.java
@@ -150,15 +150,15 @@ public class AuthRefreshControllerTest {
     }
 
     @Test
-    void refresh_oldRefreshTokenReuse_returns401() throws Exception {
+    void refresh_oldRefreshTokenReuse_terminatesAllSessions() throws Exception {
         // 테스트 목적:
-        // refresh rotation 후 이전 refresh token을 다시 쓰면
-        // 401 INVALID_REFRESH_TOKEN이 발생해야 한다
+        // refresh rotation 후 이전 refresh token(ROTATED 마킹)을 재사용하면
+        // 탈취로 간주하여 전체 세션을 종료하고 401을 반환해야 한다
 
         User savedUser = saveUser("reuse@test.com", "12345678", "홍길동", "010-1111-2222");
         LoginResult loginResult = loginAndGetResult("reuse@test.com", "12345678");
 
-        MvcResult firstRefresh = mockMvc.perform(
+        mockMvc.perform(
                         post("/api/auth/refresh")
                                 .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -166,8 +166,7 @@ public class AuthRefreshControllerTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        String newRefreshToken = extractRefreshTokenFromCookie(firstRefresh.getResponse().getHeader("Set-Cookie"));
-
+        // 이전 토큰으로 재시도 → ROTATED 마킹 감지 → logoutAll 트리거
         mockMvc.perform(
                         post("/api/auth/refresh")
                                 .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
@@ -177,15 +176,17 @@ public class AuthRefreshControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
 
+        // logoutAll로 세션 전체 삭제됨
         String refreshKey = "refresh:" + savedUser.getId() + ":" + loginResult.sessionId();
-        assertThat(stringRedisTemplate.opsForValue().get(refreshKey)).isEqualTo(newRefreshToken);
+        assertThat(stringRedisTemplate.opsForValue().get(refreshKey)).isNull();
+        assertThat(stringRedisTemplate.hasKey("refresh:sessions:" + savedUser.getId())).isFalse();
     }
 
     @Test
-    void refresh_redisMismatch_returns401() throws Exception {
+    void refresh_redisMismatch_terminatesAllSessions() throws Exception {
         // 테스트 목적:
-        // Redis에 저장된 refresh token 값과
-        // 쿠키 값이 다르면 401 INVALID_REFRESH_TOKEN이 발생해야 한다
+        // Redis에 저장된 refresh token 값과 쿠키 값이 다르면 탈취로 간주하여
+        // 전체 세션을 종료하고 401을 반환해야 한다
 
         User savedUser = saveUser("mismatch@test.com", "12345678", "홍길동", "010-1111-2222");
         LoginResult loginResult = loginAndGetResult("mismatch@test.com", "12345678");
@@ -202,9 +203,9 @@ public class AuthRefreshControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
 
-        String sessionSetKey = "refresh:sessions:" + savedUser.getId();
-        Boolean isMember = stringRedisTemplate.opsForSet().isMember(sessionSetKey, loginResult.sessionId());
-        assertThat(isMember).isFalse();
+        // logoutAll로 세션 전체 삭제됨
+        assertThat(stringRedisTemplate.opsForValue().get(refreshKey)).isNull();
+        assertThat(stringRedisTemplate.hasKey("refresh:sessions:" + savedUser.getId())).isFalse();
     }
 
     @Test
@@ -265,6 +266,68 @@ public class AuthRefreshControllerTest {
         String newRefreshToken = extractRefreshTokenFromCookie(result.getResponse().getHeader("Set-Cookie"));
         assertThat(newRefreshToken).isNotBlank();
         assertThat(newRefreshToken).isNotEqualTo(loginResult.refreshToken());
+    }
+
+    @Test
+    void refresh_success_oldLookupKeyMarkedAsRotated() throws Exception {
+        // 테스트 목적:
+        // refresh 성공 후 이전 토큰의 역조회 키가
+        // "ROTATED:" 마킹으로 5분간 유지되는지 확인
+
+        User savedUser = saveUser("rotated@test.com", "12345678", "홍길동", "010-1111-2222");
+        LoginResult loginResult = loginAndGetResult("rotated@test.com", "12345678");
+
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", loginResult.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk());
+
+        String oldLookupKey = "refresh:token:" + loginResult.refreshToken();
+        String markedValue = stringRedisTemplate.opsForValue().get(oldLookupKey);
+        assertThat(markedValue).startsWith("ROTATED:");
+        assertThat(markedValue).isEqualTo("ROTATED:" + savedUser.getId() + ":" + loginResult.sessionId());
+    }
+
+    @Test
+    void refresh_rotatedTokenReuse_terminatesOtherDeviceSessions() throws Exception {
+        // 테스트 목적:
+        // ROTATED 마킹된 토큰 재사용 시 logoutAll이 호출되어
+        // 다른 기기(핸드폰 등) 세션까지 모두 종료되어야 한다
+
+        User savedUser = saveUser("attack@test.com", "12345678", "홍길동", "010-1111-2222");
+
+        LoginResult deviceA = loginAndGetResult("attack@test.com", "12345678");
+        LoginResult deviceB = loginAndGetResult("attack@test.com", "12345678");
+
+        // deviceA refresh → tokenA가 ROTATED 마킹됨
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceA.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk());
+
+        // deviceA 이전 토큰 재사용 → 탈취 감지 → logoutAll
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .cookie(new Cookie("refreshToken", deviceA.refreshToken()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_REFRESH_TOKEN"));
+
+        // deviceA 세션 삭제
+        String refreshKeyA = "refresh:" + savedUser.getId() + ":" + deviceA.sessionId();
+        assertThat(stringRedisTemplate.opsForValue().get(refreshKeyA)).isNull();
+
+        // deviceB 세션도 함께 삭제됨 (logoutAll)
+        String refreshKeyB = "refresh:" + savedUser.getId() + ":" + deviceB.sessionId();
+        assertThat(stringRedisTemplate.opsForValue().get(refreshKeyB)).isNull();
+
+        // 세션 목록 자체도 삭제됨
+        assertThat(stringRedisTemplate.hasKey("refresh:sessions:" + savedUser.getId())).isFalse();
     }
 
     private String extractRefreshTokenFromCookie(String setCookieHeader) {

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import { LoginForm } from '@/features/auth/components/LoginForm';
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
@@ -10,6 +11,8 @@ import { loginSchema, type LoginFormValues } from '@/features/auth/schemas/auth.
 import type { ErrorResponse } from '@/types/api.types';
 
 export function LoginForm() {
+  const searchParams = useSearchParams();
+  const isSecurityLogout = searchParams.get('reason') === 'security';
   const { mutate: login, isPending } = useLogin();
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -41,6 +44,12 @@ export function LoginForm() {
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 px-4">
       <div className="w-full max-w-sm">
         <h1 className="mb-8 text-center text-2xl font-semibold text-zinc-900">로그인</h1>
+
+        {isSecurityLogout && (
+          <p className="mb-4 rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-700">
+            보안을 위해 로그아웃됐습니다. 다시 로그인해 주세요.
+          </p>
+        )}
 
         <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
           {serverError && (

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import type { ApiResponse } from '@/types/api.types';
+import axios, { type AxiosError } from 'axios';
+import type { ApiResponse, ErrorResponse } from '@/types/api.types';
 import { useAuthStore } from '@/store/auth.store';
 
 export const axiosInstance = axios.create({
@@ -25,9 +25,9 @@ function notifySubscribers(token: string) {
   subscribers = [];
 }
 
-function redirectToLogin() {
+function redirectToLogin(reason?: string) {
   if (typeof window !== 'undefined') {
-    window.location.href = '/login';
+    window.location.href = reason ? `/login?reason=${reason}` : '/login';
   }
 }
 
@@ -75,9 +75,10 @@ axiosInstance.interceptors.response.use(
 
       originalRequest.headers.Authorization = `Bearer ${newToken}`;
       return axiosInstance(originalRequest);
-    } catch {
+    } catch (refreshError) {
+      const errorCode = (refreshError as AxiosError<ErrorResponse>)?.response?.data?.errorCode;
       useAuthStore.getState().clearAuth();
-      redirectToLogin();
+      redirectToLogin(errorCode === 'INVALID_REFRESH_TOKEN' ? 'security' : undefined);
       return Promise.reject(error);
     } finally {
       isRefreshing = false;

--- a/frontend/src/types/api.types.ts
+++ b/frontend/src/types/api.types.ts
@@ -6,6 +6,8 @@ export interface ApiResponse<T> {
 
 export interface ErrorResponse {
   success: false;
+  errorCode: string;
   message: string;
-  code: string;
+  path: string;
+  timestamp: string;
 }


### PR DESCRIPTION
관련 이슈 #66

## 배경

   Refresh Token Rotation이 구현되어 있었지만, 탈취된 토큰이 재사용될 때 공격자 세션이 유지되는 허점이 있었다.

   ## 문제

   **공격자가 먼저 rotate한 경우**
   ```
   공격자 → tokenA rotate → tokenC 획득
   피해자 → tokenA 재시도 → 401 (강제 로그아웃)
   → 피해자가 재로그인해도 공격자 tokenC 세션은 살아있음
   ```

   기존 코드의 두 가지 허점:
   1. rotate 시 기존 역조회 키를 삭제해버려 탈취인지 만료인지 구분 불가
   2. 불일치 감지 시 `deleteRefreshSession()`으로 해당 세션만 삭제 (공격자 세션 유지)

   ## 해결

   ### ROTATED 마킹 도입
   rotate 시 기존 역조회 키를 삭제하지 않고 `"ROTATED:{userId}:{sessionId}"` 값으로 5분 TTL 유지

   ```
   tokenA rotate 성공
   → refresh:token:{tokenA} = "ROTATED:userId:sessionId" (5분)

   피해자가 tokenA 재시도
   → "ROTATED:..." 감지 → 탈취 확정 → logoutAll()
   ```

   ### 탈취 감지 시 logoutAll() 호출
   
   ### 탈취 감지 시 logoutAll() 호출
   
   | 경로 | 조건 | 기존 처리 | 변경 |
   |---|---|---|---|
   | 경로 A | ROTATED 마킹 토큰 재사용 | 없음 | `logoutAll()` |
   | 경로 B | 역조회 키 정상, 본체 불일치 | `deleteRefreshSession()` | `logoutAll()` |

   ### 프론트엔드 보안 안내
   - refresh 실패 시 `INVALID_REFRESH_TOKEN` 에러 코드 확인 → `/login?reason=security` 이동
   - 로그인 화면에서 "보안을 위해 로그아웃됐습니다. 다시 로그인해 주세요." 안내 배너 표시
   
   ## 변경 파일
   
   **백엔드**
   - `AuthService.java` — ROTATED 마킹, logoutAll 전환, `@Slf4j` 추가
   - `AuthRefreshControllerTest.java` — 기존 테스트 2개 수정, 신규 테스트 2개 추가
   - `auth/CLAUDE.md` — Redis 구조, Refresh 흐름, 보안 정책 업데이트
   
   **프론트엔드**
   - `axios.ts` — `redirectToLogin(reason?)` 파라미터 추가, 에러 코드 구분
   - `LoginForm.tsx` — 보안 로그아웃 안내 배너 추가 (`useSearchParams` 활용)
   - `login/page.tsx` — `Suspense` 래핑 추가
   - `api.types.ts` — `ErrorResponse.code` → `errorCode` 불일치 버그 수정