### PR TITLE
[refactor/bundle-hold] 예매 세션 단위 HOLD 구조 전환 및 동시성 테스트 추가 (#69)

### DIFF
--- a/backend/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/demo/seatreservation/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이메일 중복"),
     SEAT_DUPLICATED(HttpStatus.CONFLICT, "동일 좌석(구역/행/번호) 중복"),
     SEAT_RESERVED_CANNOT_DELETE(HttpStatus.CONFLICT, "예약 확정 좌석 삭제 불가"),
-    HOLD_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "좌석은 최대 4개까지 선택 가능");
+    HOLD_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "좌석은 최대 4개까지 선택 가능"),
+    SESSION_EXPIRED(HttpStatus.CONFLICT, "예매 세션이 만료되었거나 존재하지 않습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/controller/ReservationConfirmController.java
@@ -23,6 +23,6 @@ public class ReservationConfirmController {
             @Valid @RequestBody ReservationConfirmRequest request,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ApiResponse.ok(reservationService.confirm(principal.getUserId(), request));
+        return ApiResponse.ok(reservationService.confirmAll(principal.getUserId(), request));
     }
 }

--- a/backend/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/dto/request/ReservationConfirmRequest.java
@@ -7,8 +7,5 @@ import lombok.Getter;
 public class ReservationConfirmRequest {
 
     @NotNull
-    private Long seatId;
-
-    @NotNull
     private Long showId;
 }

--- a/backend/src/main/java/com/demo/seatreservation/seat/dto/response/ReservationConfirmResponse.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/dto/response/ReservationConfirmResponse.java
@@ -4,11 +4,13 @@ import com.demo.seatreservation.domain.enums.ReservationStatus;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class ReservationConfirmResponse {
 
-    private Long seatId;
     private Long showId;
+    private List<Long> reservedSeatIds;
     private ReservationStatus status;
 }

--- a/backend/src/main/java/com/demo/seatreservation/seat/redis/HoldKey.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/redis/HoldKey.java
@@ -6,4 +6,9 @@ public final class HoldKey {
     public static String of(Long showId, Long seatId) {
         return "hold:" + showId + ":" + seatId;
     }
+
+    // 예매 묶음 키 생성
+    public static String bundleOf(Long showId, Long userId) {
+        return "hold:bundle:" + showId + ":" + userId;
+    }
 }

--- a/backend/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/redis/HoldRedisRepository.java
@@ -1,13 +1,63 @@
 package com.demo.seatreservation.seat.redis;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Repository
 public class HoldRedisRepository {
+
+    // 결과 규약: -1 = HOLD_LIMIT_EXCEEDED, -2 = SEAT_ALREADY_HELD, -3 = 예기치 않은 상태, >=0 = 성공(잔여 TTL 초)
+    private static final DefaultRedisScript<Long> TRY_HOLD_SCRIPT;
+
+    static {
+        TRY_HOLD_SCRIPT = new DefaultRedisScript<>();
+        TRY_HOLD_SCRIPT.setResultType(Long.class);
+        TRY_HOLD_SCRIPT.setScriptText("""
+                local bundleKey   = KEYS[1]
+                local seatKey     = KEYS[2]
+                local userId      = ARGV[1]
+                local seatId      = ARGV[2]
+                local maxSeats    = tonumber(ARGV[3])
+                local bundleTtlSec = tonumber(ARGV[4])
+
+                local pttl = redis.call('PTTL', bundleKey)
+                local seatTtlMs
+                local isFirstSeat
+
+                if pttl == -2 then
+                    seatTtlMs    = bundleTtlSec * 1000
+                    isFirstSeat  = 1
+                elseif pttl > 0 then
+                    seatTtlMs    = pttl
+                    isFirstSeat  = 0
+                else
+                    return -3
+                end
+
+                local count = redis.call('SCARD', bundleKey)
+                if count >= maxSeats then
+                    return -1
+                end
+
+                local ok = redis.call('SET', seatKey, userId, 'PX', seatTtlMs, 'NX')
+                if not ok then
+                    return -2
+                end
+
+                redis.call('SADD', bundleKey, seatId)
+
+                if isFirstSeat == 1 then
+                    redis.call('EXPIRE', bundleKey, bundleTtlSec)
+                end
+
+                return math.floor(seatTtlMs / 1000)
+                """);
+    }
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -15,10 +65,44 @@ public class HoldRedisRepository {
         this.redisTemplate = redisTemplate;
     }
 
-    // NX + TTL
-    public boolean tryHold(String key, String userId, Duration ttl) {
-        Boolean ok = redisTemplate.opsForValue().setIfAbsent(key, userId, ttl);
-        return Boolean.TRUE.equals(ok);
+    /**
+     * Lua 스크립트로 PTTL → SCARD → SET NX PX → SADD → (EXPIRE) 를 원자적으로 실행한다.
+     * 반환값: -1(4석 초과), -2(좌석 이미 선점됨), -3(예기치 않은 상태), >=0(성공, 잔여 TTL 초)
+     */
+    public long executeTryHold(String bundleKey, String seatKey,
+                               String userId, String seatId, long bundleTtlSec) {
+        Long result = redisTemplate.execute(
+                TRY_HOLD_SCRIPT,
+                List.of(bundleKey, seatKey),
+                userId, seatId, "4", String.valueOf(bundleTtlSec)
+        );
+        return result == null ? -3L : result;
+    }
+
+    /** bundle 잔여 TTL(ms). 키 없음 → -2, TTL 없음 → -1 */
+    public long getBundleRemainingTtlMs(String bundleKey) {
+        Long ttl = redisTemplate.getExpire(bundleKey, TimeUnit.MILLISECONDS);
+        return ttl == null ? -2L : ttl;
+    }
+
+    public Set<String> getBundleSeatIds(String bundleKey) {
+        return redisTemplate.opsForSet().members(bundleKey);
+    }
+
+    public Long getBundleSize(String bundleKey) {
+        return redisTemplate.opsForSet().size(bundleKey);
+    }
+
+    public void removeFromBundle(String bundleKey, Long seatId) {
+        redisTemplate.opsForSet().remove(bundleKey, String.valueOf(seatId));
+    }
+
+    public void deleteBundle(String bundleKey) {
+        redisTemplate.delete(bundleKey);
+    }
+
+    public String getOwner(String key) {
+        return redisTemplate.opsForValue().get(key);
     }
 
     public long getTtlSec(String key) {
@@ -26,28 +110,7 @@ public class HoldRedisRepository {
         return ttl == null ? -2L : ttl;
     }
 
-    public String getOwner(String key) {
-        return redisTemplate.opsForValue().get(key);
-    }
-
     public void delete(String key) {
         redisTemplate.delete(key);
     }
-
-    // 사용자 HOLD 개수 조회
-    public Long getUserHoldCount(String userHoldKey) {
-        return redisTemplate.opsForSet().size(userHoldKey);
-    }
-
-    // 사용자 HOLD 추가
-    public void addUserHold(String userHoldKey, Long seatId, Duration ttl) {
-        redisTemplate.opsForSet().add(userHoldKey, String.valueOf(seatId));
-        redisTemplate.expire(userHoldKey, ttl);
-    }
-
-    // 사용자 HOLD 제거
-    public void removeUserHold(String userHoldKey, Long seatId) {
-        redisTemplate.opsForSet().remove(userHoldKey, String.valueOf(seatId));
-    }
-
 }

--- a/backend/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/service/ReservationService.java
@@ -13,6 +13,11 @@ import com.demo.seatreservation.seat.redis.HoldRedisRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+import java.util.Set;
 
 @Service
 public class ReservationService {
@@ -28,58 +33,55 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationConfirmResponse confirm(Long userId, ReservationConfirmRequest request) {
-
-        Long seatId = request.getSeatId();
+    public ReservationConfirmResponse confirmAll(Long userId, ReservationConfirmRequest request) {
         Long showId = request.getShowId();
+        String bundleKey = HoldKey.bundleOf(showId, userId);
 
-        String holdKey = HoldKey.of(showId, seatId);
-
-        // 1. HOLD 존재 확인
-        String owner = holdRedisRepository.getOwner(holdKey);
-
-        if (owner == null) {
-            throw new BusinessException(ErrorCode.HOLD_EXPIRED);
+        // 1. 번들 존재 확인 (PTTL -2 == 키 없음)
+        long bundleTtlMs = holdRedisRepository.getBundleRemainingTtlMs(bundleKey);
+        if (bundleTtlMs == -2L) {
+            throw new BusinessException(ErrorCode.SESSION_EXPIRED);
         }
 
-        // 2. HOLD 소유자 확인
-        if (!owner.equals(String.valueOf(userId))) {
-            throw new BusinessException(ErrorCode.NOT_HOLD_OWNER);
+        // 2. 번들에서 좌석 목록 조회
+        Set<String> seatIdStrs = holdRedisRepository.getBundleSeatIds(bundleKey);
+        if (seatIdStrs == null || seatIdStrs.isEmpty()) {
+            throw new BusinessException(ErrorCode.SESSION_EXPIRED);
         }
 
-        // 3. DB 예약 중복 확인
-        if (reservationRepository.existsByShowIdAndSeatIdAndStatus(
-                showId,
-                seatId,
-                ReservationStatus.RESERVED
-        )) {
-            throw new BusinessException(ErrorCode.ALREADY_RESERVED);
-        }
+        List<Long> seatIds = seatIdStrs.stream().map(Long::parseLong).toList();
 
-        // 4. DB 예약 저장
+        // 3. DB 커밋 후 Redis 정리 (afterCommit)
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (Long seatId : seatIds) {
+                    holdRedisRepository.delete(HoldKey.of(showId, seatId));
+                }
+                holdRedisRepository.deleteBundle(bundleKey);
+            }
+        });
+
+        // 4. 전체 좌석 일괄 예약 저장
+        // flush()로 UNIQUE 위반을 커밋 전에 강제 표면화 — 테스트에서 즉시 잡히도록
         try {
-            reservationRepository.save(
-                    Reservation.builder()
+            List<Reservation> reservations = seatIds.stream()
+                    .map(seatId -> Reservation.builder()
                             .seatId(seatId)
                             .showId(showId)
                             .userId(userId)
                             .status(ReservationStatus.RESERVED)
-                            .build()
-            );
-
+                            .build())
+                    .toList();
+            reservationRepository.saveAll(reservations);
+            reservationRepository.flush();
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.ALREADY_RESERVED);
         }
 
-        // 5. Redis HOLD 삭제
-        holdRedisRepository.delete(holdKey);
-
-        String userHoldKey = "hold:user:" + showId + ":" + userId;
-        holdRedisRepository.removeUserHold(userHoldKey, seatId);
-
         return ReservationConfirmResponse.builder()
-                .seatId(seatId)
                 .showId(showId)
+                .reservedSeatIds(seatIds)
                 .status(ReservationStatus.RESERVED)
                 .build();
     }
@@ -101,7 +103,7 @@ public class ReservationService {
             throw new BusinessException(ErrorCode.ALREADY_CANCELED);
         }
 
-        // 4. 예약 취소 (도메인 메서드 사용)
+        // 4. 예약 취소
         reservation.cancel();
 
         return ReservationCancelResponse.builder()

--- a/backend/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
+++ b/backend/src/main/java/com/demo/seatreservation/seat/service/SeatHoldService.java
@@ -1,7 +1,5 @@
 package com.demo.seatreservation.seat.service;
 
-import java.time.Duration;
-
 import com.demo.seatreservation.seat.dto.request.SeatHoldCancelRequest;
 import com.demo.seatreservation.seat.dto.response.SeatHoldCancelResponse;
 import org.springframework.stereotype.Service;
@@ -19,7 +17,7 @@ import com.demo.seatreservation.seat.redis.HoldRedisRepository;
 @Service
 public class SeatHoldService {
 
-    private static final Duration HOLD_TTL = Duration.ofSeconds(300);
+    private static final long HOLD_TTL_SEC = 300L;
 
     private final HoldRedisRepository holdRedisRepository;
     private final ReservationRepository reservationRepository;
@@ -34,62 +32,62 @@ public class SeatHoldService {
     public SeatHoldResponse hold(Long seatId, Long userId, SeatHoldRequest request) {
         Long showId = request.getShowId();
 
-        // 1) DB에 이미 RESERVED 있으면 막기
-        boolean alreadyReserved = reservationRepository
-                .existsByShowIdAndSeatIdAndStatus(showId, seatId, ReservationStatus.RESERVED);
-
-        if (alreadyReserved) {
+        // 1. DB에 이미 RESERVED이면 선점 불가
+        if (reservationRepository.existsByShowIdAndSeatIdAndStatus(showId, seatId, ReservationStatus.RESERVED)) {
             throw new BusinessException(ErrorCode.ALREADY_RESERVED);
         }
 
-        // 2) 사용자 HOLD 제한
-        String userHoldKey = "hold:user:" + showId + ":" + userId;
+        // 2. Lua Script로 원자적으로 PTTL → SCARD → SET NX PX → SADD → (EXPIRE) 실행
+        String bundleKey = HoldKey.bundleOf(showId, userId);
+        String seatKey   = HoldKey.of(showId, seatId);
 
-        Long count = holdRedisRepository.getUserHoldCount(userHoldKey);
+        long result = holdRedisRepository.executeTryHold(
+                bundleKey, seatKey,
+                String.valueOf(userId), String.valueOf(seatId),
+                HOLD_TTL_SEC
+        );
 
-        if (count != null && count >= 4) {
+        if (result == -1L) {
             throw new BusinessException(ErrorCode.HOLD_LIMIT_EXCEEDED);
         }
-
-        // 3) Redis NX + TTL hold
-        String key = HoldKey.of(showId, seatId);
-        boolean ok = holdRedisRepository.tryHold(key, String.valueOf(userId), HOLD_TTL);
-
-        if (!ok) {
+        if (result == -2L) {
             throw new BusinessException(ErrorCode.SEAT_ALREADY_HELD);
         }
+        if (result == -3L) {
+            // bundle key가 TTL=0(pttl==-1)인 비정상 상태 — 방어적으로 처리
+            throw new BusinessException(ErrorCode.SESSION_EXPIRED);
+        }
 
-        holdRedisRepository.addUserHold(userHoldKey, seatId, HOLD_TTL);
-
-        // 4) TTL 응답
-        long expiresInSec = holdRedisRepository.getTtlSec(key);
-        return SeatHoldResponse.held(seatId, showId, expiresInSec);
+        // result == Lua Script가 반환한 잔여 TTL 초 (floor(seatTtlMs/1000))
+        return SeatHoldResponse.held(seatId, showId, result);
     }
 
-    @Transactional
     public SeatHoldCancelResponse cancelHold(Long seatId, Long userId, SeatHoldCancelRequest request) {
-
         Long showId = request.getShowId();
 
-        String key = HoldKey.of(showId, seatId);
-        String userHoldKey = "hold:user:" + showId + ":" + userId;
+        String seatKey   = HoldKey.of(showId, seatId);
+        String bundleKey = HoldKey.bundleOf(showId, userId);
 
-        // 1. hold 존재 확인
-        String owner = holdRedisRepository.getOwner(key);
-
+        // 1. HOLD 존재 확인
+        String owner = holdRedisRepository.getOwner(seatKey);
         if (owner == null) {
             throw new BusinessException(ErrorCode.HOLD_EXPIRED);
         }
 
-        // 2. owner 확인
+        // 2. 소유자 확인
         if (!owner.equals(String.valueOf(userId))) {
             throw new BusinessException(ErrorCode.NOT_HOLD_OWNER);
         }
 
-        // 3. key 삭제
-        holdRedisRepository.delete(key);
+        // 3. 좌석 키 삭제
+        holdRedisRepository.delete(seatKey);
 
-        holdRedisRepository.removeUserHold(userHoldKey, seatId);
+        // 4. 번들에서 제거; 비어 있으면 번들도 삭제
+        holdRedisRepository.removeFromBundle(bundleKey, seatId);
+        Long remaining = holdRedisRepository.getBundleSize(bundleKey);
+        if (remaining == null || remaining == 0L) {
+            holdRedisRepository.deleteBundle(bundleKey);
+        }
 
         return SeatHoldCancelResponse.available(seatId, showId);
     }

--- a/backend/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
+++ b/backend/src/test/java/com/demo/seatreservation/seat/controller/ReservationConfirmControllerTest.java
@@ -9,6 +9,7 @@ import com.demo.seatreservation.repository.ReservationRepository;
 import com.demo.seatreservation.repository.SeatRepository;
 import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.seat.redis.HoldKey;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,9 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -49,15 +53,6 @@ public class ReservationConfirmControllerTest {
         redisTemplate.getConnectionFactory()
                 .getConnection()
                 .flushAll();
-
-        seatRepository.save(
-                Seat.builder()
-                        .showId(1L)
-                        .zone("A")
-                        .row(1)
-                        .number(1)
-                        .build()
-        );
     }
 
     private User saveUser(String email) {
@@ -87,151 +82,176 @@ public class ReservationConfirmControllerTest {
         return root.get("data").get("accessToken").asText();
     }
 
+    private Seat createSeat(Long showId, int number) {
+        return seatRepository.save(
+                Seat.builder()
+                        .showId(showId)
+                        .zone("A")
+                        .row(1)
+                        .number(number)
+                        .build()
+        );
+    }
+
+    /** 테스트용 번들 상태 직접 Redis에 세팅 */
+    private void setupBundle(Long showId, Long userId, List<Long> seatIds) {
+        String bundleKey = HoldKey.bundleOf(showId, userId);
+        for (Long seatId : seatIds) {
+            redisTemplate.opsForSet().add(bundleKey, String.valueOf(seatId));
+            String seatKey = HoldKey.of(showId, seatId);
+            redisTemplate.opsForValue().set(seatKey, String.valueOf(userId));
+            redisTemplate.expire(seatKey, 300, TimeUnit.SECONDS);
+        }
+        redisTemplate.expire(bundleKey, 300, TimeUnit.SECONDS);
+    }
+
     @Test
-    void confirm_success_shouldReserveSeat() throws Exception {
-        // 테스트 목적:
-        // 1) 정상적인 HOLD 상태에서 예약 확정 요청 시 200 OK 반환
-        // 2) DB에 RESERVED 상태의 예약이 생성되는지 확인
-        // 3) Redis HOLD 키가 삭제되는지 확인
+    void confirmAll_success_shouldReserveSeats() throws Exception {
+        // 정상 번들 상태에서 confirmAll 요청 시 200 OK 및 DB 예약 생성 확인
         User user = saveUser("confirm@test.com");
         String token = loginAndGetToken("confirm@test.com");
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1L, 1);
+        Long seatId = seat.getId();
         Long showId = 1L;
 
-        // Redis HOLD 생성 (실제 user ID로 선점)
-        String key = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
+        setupBundle(showId, user.getId(), List.of(seatId));
 
         mockMvc.perform(post("/api/reservations/confirm")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": %d
-                                }
-                                """.formatted(seatId, showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.status").value("RESERVED"));
+                .andExpect(jsonPath("$.data.status").value("RESERVED"))
+                .andExpect(jsonPath("$.data.reservedSeatIds").isArray())
+                .andExpect(jsonPath("$.data.reservedSeatIds[0]").value(seatId));
 
         // DB에 예약이 생성되었는지 확인
-        Reservation reservation = reservationRepository.findAll().get(0);
-        org.junit.jupiter.api.Assertions.assertEquals(ReservationStatus.RESERVED, reservation.getStatus());
-
-        // Redis HOLD 삭제 확인
-        String owner = redisTemplate.opsForValue().get(key);
-        org.junit.jupiter.api.Assertions.assertNull(owner);
+        List<Reservation> reservations = reservationRepository.findAll();
+        Assertions.assertEquals(1, reservations.size());
+        Assertions.assertEquals(ReservationStatus.RESERVED, reservations.get(0).getStatus());
+        Assertions.assertEquals(seatId, reservations.get(0).getSeatId());
     }
 
     @Test
-    void confirm_withoutHold_shouldReturn409() throws Exception {
-        // 테스트 목적:
-        // Redis에 HOLD 키가 존재하지 않는 상태에서
-        // 예약 확정 요청 시 409 HOLD_EXPIRED 에러가 발생해야 한다
+    void confirmAll_multiSeat_shouldReserveAll() throws Exception {
+        // 여러 좌석 번들 → 전부 예약 확정
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
+
+        Seat seat1 = createSeat(1L, 1);
+        Seat seat2 = createSeat(1L, 2);
+        Seat seat3 = createSeat(1L, 3);
+        Long showId = 1L;
+        List<Long> seatIds = List.of(seat1.getId(), seat2.getId(), seat3.getId());
+
+        setupBundle(showId, user.getId(), seatIds);
+
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("RESERVED"))
+                .andExpect(jsonPath("$.data.reservedSeatIds").isArray());
+
+        List<Reservation> reservations = reservationRepository.findAll();
+        Assertions.assertEquals(3, reservations.size());
+        reservations.forEach(r -> Assertions.assertEquals(ReservationStatus.RESERVED, r.getStatus()));
+    }
+
+    @Test
+    void confirmAll_redisCleanedUpAfterCommit() throws Exception {
+        // DB 커밋 후 seat 키와 bundle 키가 모두 삭제되는지 확인
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
+
+        Seat seat = createSeat(1L, 1);
+        Long seatId = seat.getId();
+        Long showId = 1L;
+        String seatKey   = HoldKey.of(showId, seatId);
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
+
+        setupBundle(showId, user.getId(), List.of(seatId));
+
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isOk());
+
+        // seat 키 삭제 확인
+        Assertions.assertNull(redisTemplate.opsForValue().get(seatKey));
+        // bundle 키 삭제 확인
+        Assertions.assertFalse(Boolean.TRUE.equals(redisTemplate.hasKey(bundleKey)));
+    }
+
+    @Test
+    void confirmAll_noBundle_returns409_sessionExpired() throws Exception {
+        // 번들 없이 confirmAll 요청 시 SESSION_EXPIRED 409
         saveUser("confirm@test.com");
         String token = loginAndGetToken("confirm@test.com");
 
-        Long seatId = seatRepository.findAll().get(0).getId();
-
         mockMvc.perform(post("/api/reservations/confirm")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": 1
-                                }
-                                """.formatted(seatId)))
-                .andExpect(status().isConflict());
+                                {"showId": 1}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SESSION_EXPIRED"));
     }
 
     @Test
-    void confirm_notOwner_shouldReturn403() throws Exception {
-        // 테스트 목적:
-        // HOLD를 건 사용자와 다른 userId가 예약 확정을 시도할 경우
-        // 403 NOT_HOLD_OWNER 에러가 발생해야 한다
-        User user1 = saveUser("user1@test.com");
-        User user2 = saveUser("user2@test.com");
-        String token1 = loginAndGetToken("user1@test.com");
-
-        Long seatId = seatRepository.findAll().get(0).getId();
-        Long showId = 1L;
-
-        // user2가 선점한 HOLD
-        String key = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(key, String.valueOf(user2.getId()));
-
-        // user1이 예약 확정 시도
-        mockMvc.perform(post("/api/reservations/confirm")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": %d
-                                }
-                                """.formatted(seatId, showId)))
-                .andExpect(status().isForbidden());
-    }
-
-    @Test
-    void confirm_twice_shouldReturnAlreadyReserved() throws Exception {
-        // 테스트 목적:
-        // 동일 좌석에 대해 예약 확정을 두 번 시도할 경우
-        // 두 번째 요청은 409 ALREADY_RESERVED 에러가 발생해야 한다
+    void confirmAll_twice_secondReturns409_sessionExpired() throws Exception {
+        // 두 번째 confirmAll 요청 시 bundle이 삭제된 상태 → SESSION_EXPIRED 409
         User user = saveUser("confirm@test.com");
         String token = loginAndGetToken("confirm@test.com");
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1L, 1);
+        Long seatId = seat.getId();
         Long showId = 1L;
 
-        String key = HoldKey.of(showId, seatId);
+        setupBundle(showId, user.getId(), List.of(seatId));
 
-        // 첫 번째 HOLD 생성
-        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
-
-        // 첫 번째 confirm (성공)
+        // 첫 번째 confirm 성공
         mockMvc.perform(post("/api/reservations/confirm")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": %d
-                                }
-                                """.formatted(seatId, showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // 두 번째 confirm을 위해 다시 HOLD 생성
-        redisTemplate.opsForValue().set(key, String.valueOf(user.getId()));
-
-        // 두 번째 confirm (이미 예약됨 → 실패)
+        // 두 번째 confirm → bundle 없음 → SESSION_EXPIRED
         mockMvc.perform(post("/api/reservations/confirm")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": %d
-                                }
-                                """.formatted(seatId, showId)))
-                .andExpect(status().isConflict());
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SESSION_EXPIRED"));
     }
 
     @Test
-    void confirm_whenAlreadyReservedExists_shouldReturnAlreadyReserved() throws Exception {
-        // 테스트 목적:
-        // 이미 DB에 RESERVED 상태의 예약이 존재하는 경우
-        // existsBy... 사전 체크에서 바로 중복을 감지하여 실패해야 한다
+    void confirmAll_whenSeatAlreadyReservedInDb_returns409() throws Exception {
+        // DB에 이미 RESERVED 예약 존재 → saveAll 시 UNIQUE 위반 → ALREADY_RESERVED 409
         User user = saveUser("confirm@test.com");
         String token = loginAndGetToken("confirm@test.com");
 
-        Long seatId = seatRepository.findAll().get(0).getId();
+        Seat seat = createSeat(1L, 1);
+        Long seatId = seat.getId();
         Long showId = 1L;
 
-        // DB에 이미 RESERVED 예약 존재
+        // DB에 이미 예약 존재
         reservationRepository.save(
                 Reservation.builder()
                         .seatId(seatId)
@@ -241,37 +261,77 @@ public class ReservationConfirmControllerTest {
                         .build()
         );
 
-        // Redis HOLD는 현재 요청 사용자 것으로 생성
-        String holdKey = HoldKey.of(showId, seatId);
-        redisTemplate.opsForValue().set(holdKey, String.valueOf(user.getId()));
+        setupBundle(showId, user.getId(), List.of(seatId));
 
         mockMvc.perform(post("/api/reservations/confirm")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": %d
-                                }
-                                """.formatted(seatId, showId)))
+                                {"showId": %d}
+                                """.formatted(showId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("ALREADY_RESERVED"));
     }
 
     @Test
-    void confirm_noAuthToken_returns401() throws Exception {
-        // 테스트 목적:
-        // Authorization 헤더 없이 confirm 요청 시 401이 발생해야 한다
-        Long seatId = seatRepository.findAll().get(0).getId();
-
+    void confirmAll_noAuthToken_returns401() throws Exception {
         mockMvc.perform(post("/api/reservations/confirm")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {
-                                  "seatId": %d,
-                                  "showId": 1
-                                }
-                                """.formatted(seatId)))
+                                {"showId": 1}
+                                """))
                 .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * 테스트 목적:
+     * bundle에 seatA·seatB 2석이 있을 때, seatA가 이미 DB에 RESERVED 상태이면
+     * saveAll + flush 시 UNIQUE 위반으로 트랜잭션 전체가 롤백되어
+     * seatB도 저장되지 않아야 한다. (all-or-nothing 보장)
+     *
+     * 기대 결과:
+     * - HTTP 409 ALREADY_RESERVED
+     * - DB 예약 건수 = 1 (기존 seatA 예약만 남아 있음)
+     * - seatB에 대한 예약이 생성되지 않음
+     */
+    @Test
+    void confirmAll_partialDuplicate_rollbacksAll() throws Exception {
+        User user = saveUser("confirm@test.com");
+        String token = loginAndGetToken("confirm@test.com");
+
+        Seat seatA = createSeat(1L, 1);
+        Seat seatB = createSeat(1L, 2);
+        Long showId = 1L;
+
+        // seatA는 다른 사용자가 이미 예약 완료
+        reservationRepository.save(
+                Reservation.builder()
+                        .seatId(seatA.getId())
+                        .showId(showId)
+                        .userId(999L)
+                        .status(ReservationStatus.RESERVED)
+                        .build()
+        );
+
+        // bundle에 seatA·seatB 모두 포함
+        setupBundle(showId, user.getId(), List.of(seatA.getId(), seatB.getId()));
+
+        mockMvc.perform(post("/api/reservations/confirm")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("ALREADY_RESERVED"));
+
+        // seatA의 기존 예약 1건만 남고, seatB는 저장되지 않았어야 한다
+        Assertions.assertEquals(1L, reservationRepository.count(),
+                "UNIQUE 위반 시 트랜잭션 전체가 롤백되어야 하며 seatB도 저장되면 안 된다");
+
+        // seatB에 대한 현재 사용자의 예약이 없는지 명시적 확인
+        boolean seatBReserved = reservationRepository.existsByShowIdAndSeatIdAndStatus(
+                showId, seatB.getId(), ReservationStatus.RESERVED);
+        Assertions.assertFalse(seatBReserved, "seatB는 예약되지 않아야 한다");
     }
 }

--- a/backend/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
+++ b/backend/src/test/java/com/demo/seatreservation/seat/controller/SeatHoldControllerTest.java
@@ -4,8 +4,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import com.demo.seatreservation.domain.Reservation;
@@ -15,6 +21,7 @@ import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
 import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.seat.redis.HoldKey;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,10 +110,7 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_success_createsRedisKeyWithTtl() throws Exception {
-        // 테스트 목적:
-        // 1) hold 요청이 성공(200)하는지
-        // 2) 응답 JSON이 성공 형태로 내려오는지
-        // 3) Redis에 hold 키가 생성되고 TTL이 설정되는지(선점이 실제로 걸렸는지)
+        // seat hold 키 생성, bundle 키 생성, TTL 설정 모두 확인
         User user = saveUser("hold@test.com");
         String token = loginAndGetToken("hold@test.com");
 
@@ -114,7 +118,8 @@ class SeatHoldControllerTest {
         Long seatId = seat.getId();
         long showId = 1L;
 
-        String key = HoldKey.of(showId, seatId);
+        String seatKey   = HoldKey.of(showId, seatId);
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
 
         mockMvc.perform(
                         post("/api/seats/{seatId}/hold", seatId)
@@ -131,18 +136,24 @@ class SeatHoldControllerTest {
                 .andExpect(jsonPath("$.data.status").value("HELD"))
                 .andExpect(jsonPath("$.data.expiresInSec").isNumber());
 
-        String owner = stringRedisTemplate.opsForValue().get(key);
-        Long ttl = stringRedisTemplate.getExpire(key, TimeUnit.SECONDS);
+        // seat hold 키 검증
+        String owner = stringRedisTemplate.opsForValue().get(seatKey);
+        Long seatTtl = stringRedisTemplate.getExpire(seatKey, TimeUnit.SECONDS);
+        Assertions.assertEquals(String.valueOf(user.getId()), owner);
+        Assertions.assertNotNull(seatTtl);
+        Assertions.assertTrue(seatTtl > 0 && seatTtl <= 300);
 
-        org.junit.jupiter.api.Assertions.assertEquals(String.valueOf(user.getId()), owner);
-        org.junit.jupiter.api.Assertions.assertNotNull(ttl);
-        org.junit.jupiter.api.Assertions.assertTrue(ttl > 0 && ttl <= 300);
+        // bundle 키 검증
+        Set<String> bundleMembers = stringRedisTemplate.opsForSet().members(bundleKey);
+        Long bundleTtl = stringRedisTemplate.getExpire(bundleKey, TimeUnit.SECONDS);
+        Assertions.assertNotNull(bundleMembers);
+        Assertions.assertTrue(bundleMembers.contains(String.valueOf(seatId)));
+        Assertions.assertNotNull(bundleTtl);
+        Assertions.assertTrue(bundleTtl > 0 && bundleTtl <= 300);
     }
 
     @Test
     void hold_noAuthToken_returns401() throws Exception {
-        // 테스트 목적:
-        // Authorization 헤더 없이 hold 요청 시 401이 발생해야 한다
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
 
@@ -158,9 +169,7 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_twice_returns409_seatAlreadyHeld() throws Exception {
-        // 테스트 목적:
-        // 이미 선점된 좌석을 다른 사용자가 다시 hold하려고 하면
-        // 409 Conflict로 막히는지(= SEAT_ALREADY_HELD 케이스)
+        // 이미 선점된 좌석을 다른 사용자가 hold → SEAT_ALREADY_HELD 409
         saveUser("user1@test.com");
         saveUser("user2@test.com");
         String token1 = loginAndGetToken("user1@test.com");
@@ -170,7 +179,6 @@ class SeatHoldControllerTest {
         Long seatId = seat.getId();
         long showId = 1L;
 
-        // 1차 hold (user1 성공)
         mockMvc.perform(
                 post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
@@ -180,7 +188,6 @@ class SeatHoldControllerTest {
                                 """.formatted(showId))
         ).andExpect(status().isOk());
 
-        // 2차 hold (user2 → 충돌 409)
         mockMvc.perform(
                         post("/api/seats/{seatId}/hold", seatId)
                                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
@@ -194,10 +201,8 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_afterTtlExpired_canHoldAgain() throws Exception {
-        // 테스트 목적:
-        // TTL이 만료되면 선점 키가 사라지고
-        // 다른 사용자가 같은 좌석을 다시 hold 할 수 있어야 한다
-        saveUser("user1@test.com");
+        // seat hold 키와 bundle 키가 모두 만료된 후 다른 사용자가 같은 좌석을 hold 가능
+        User user1 = saveUser("user1@test.com");
         saveUser("user2@test.com");
         String token1 = loginAndGetToken("user1@test.com");
         String token2 = loginAndGetToken("user2@test.com");
@@ -206,9 +211,9 @@ class SeatHoldControllerTest {
         Long seatId = seat.getId();
         long showId = 1L;
 
-        String key = HoldKey.of(showId, seatId);
+        String seatKey    = HoldKey.of(showId, seatId);
+        String bundleKey1 = HoldKey.bundleOf(showId, user1.getId());
 
-        // user1 1차 hold 성공
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -217,11 +222,11 @@ class SeatHoldControllerTest {
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // TTL을 테스트용으로 1초로 줄여서 만료시키기
-        stringRedisTemplate.expire(key, 1, TimeUnit.SECONDS);
+        // user1의 seat 키와 bundle 키 모두 만료
+        stringRedisTemplate.expire(seatKey, 1, TimeUnit.SECONDS);
+        stringRedisTemplate.expire(bundleKey1, 1, TimeUnit.SECONDS);
         Thread.sleep(1500);
 
-        // user2 만료 후 다시 hold → 성공해야 정상
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -234,9 +239,6 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_onReservedSeat_returns409_alreadyReserved() throws Exception {
-        // 테스트 목적:
-        // DB에 이미 RESERVED 상태의 예약이 있으면
-        // hold 요청을 거절해야 한다(= ALREADY_RESERVED 케이스)
         saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
@@ -264,8 +266,6 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_missingShowId_returns400() throws Exception {
-        // 테스트 목적:
-        // showId는 필수(@NotNull)라서 누락되면 400 Bad Request가 나와야 정상
         saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
@@ -281,19 +281,17 @@ class SeatHoldControllerTest {
 
     @Test
     void cancelHold_success_returnsAvailable() throws Exception {
-        // 테스트 목적:
-        // 1) 정상적인 hold 취소 요청 시 200 OK 반환
-        // 2) Redis hold 키가 삭제되는지 확인
-        saveUser("user@test.com");
+        // hold 취소 성공: seat 키 삭제, 마지막 좌석이므로 bundle 키도 삭제
+        User user = saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
         Seat seat = createSeat(1L, 1);
         Long seatId = seat.getId();
         long showId = 1L;
 
-        String key = HoldKey.of(showId, seatId);
+        String seatKey   = HoldKey.of(showId, seatId);
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
 
-        // 먼저 hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -302,7 +300,6 @@ class SeatHoldControllerTest {
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // hold 취소 요청
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -313,16 +310,15 @@ class SeatHoldControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("AVAILABLE"));
 
-        // Redis key 삭제 확인
-        String owner = stringRedisTemplate.opsForValue().get(key);
-        org.junit.jupiter.api.Assertions.assertNull(owner);
+        // seat 키 삭제 확인
+        Assertions.assertNull(stringRedisTemplate.opsForValue().get(seatKey));
+        // 마지막 좌석이었으므로 bundle 키도 삭제 확인
+        Long bundleSize = stringRedisTemplate.opsForSet().size(bundleKey);
+        Assertions.assertTrue(bundleSize == null || bundleSize == 0L);
     }
 
     @Test
     void cancelHold_notOwner_returns403() throws Exception {
-        // 테스트 목적:
-        // HOLD를 건 사용자와 다른 userId가 취소하려 하면
-        // 403 NOT_HOLD_OWNER가 발생해야 한다
         saveUser("user1@test.com");
         saveUser("user2@test.com");
         String token1 = loginAndGetToken("user1@test.com");
@@ -332,7 +328,6 @@ class SeatHoldControllerTest {
         Long seatId = seat.getId();
         long showId = 1L;
 
-        // user1이 hold
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -341,7 +336,6 @@ class SeatHoldControllerTest {
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // user2가 취소 시도
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -353,9 +347,6 @@ class SeatHoldControllerTest {
 
     @Test
     void cancelHold_expired_returns409() throws Exception {
-        // 테스트 목적:
-        // HOLD가 이미 만료되었거나 존재하지 않을 때
-        // 409 HOLD_EXPIRED가 발생해야 한다
         saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
@@ -363,9 +354,8 @@ class SeatHoldControllerTest {
         Long seatId = seat.getId();
         long showId = 1L;
 
-        String key = HoldKey.of(showId, seatId);
+        String seatKey = HoldKey.of(showId, seatId);
 
-        // hold 생성
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -374,11 +364,9 @@ class SeatHoldControllerTest {
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // TTL 강제 만료
-        stringRedisTemplate.expire(key, 1, TimeUnit.SECONDS);
+        stringRedisTemplate.expire(seatKey, 1, TimeUnit.SECONDS);
         Thread.sleep(1500);
 
-        // 취소 시도
         mockMvc.perform(delete("/api/seats/{seatId}/hold", seatId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -390,16 +378,13 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_exceedsLimit_returns409() throws Exception {
-        // 테스트 목적:
-        // 한 사용자가 4개까지는 HOLD 가능하지만
-        // 5번째 HOLD 시도는 409 HOLD_LIMIT_EXCEEDED 발생해야 한다
+        // 4석까지 hold 가능, 5번째 시도 → HOLD_LIMIT_EXCEEDED 409
         saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
         long showId = 1L;
         List<Seat> seats = createSeats(showId, 5);
 
-        // 1~4번 좌석 HOLD 성공
         for (int i = 0; i < 4; i++) {
             Long seatId = seats.get(i).getId();
 
@@ -412,7 +397,6 @@ class SeatHoldControllerTest {
                     .andExpect(status().isOk());
         }
 
-        // 5번째 HOLD → 실패해야 정상
         Long seatId5 = seats.get(4).getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", seatId5)
@@ -426,16 +410,13 @@ class SeatHoldControllerTest {
 
     @Test
     void hold_afterCancel_canHoldAgain() throws Exception {
-        // 테스트 목적:
-        // 4개 HOLD 상태에서 하나 cancel 하면
-        // 다시 HOLD가 가능해야 한다
+        // 4석 hold 후 1석 cancel → 5번째 hold 성공
         saveUser("user@test.com");
         String token = loginAndGetToken("user@test.com");
 
         long showId = 1L;
         List<Seat> seats = createSeats(showId, 5);
 
-        // 4개 HOLD
         for (int i = 0; i < 4; i++) {
             Long seatId = seats.get(i).getId();
 
@@ -448,7 +429,6 @@ class SeatHoldControllerTest {
                     .andExpect(status().isOk());
         }
 
-        // 하나 cancel
         Long cancelSeatId = seats.get(0).getId();
 
         mockMvc.perform(delete("/api/seats/{seatId}/hold", cancelSeatId)
@@ -459,7 +439,6 @@ class SeatHoldControllerTest {
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
 
-        // 다시 HOLD → 성공해야 정상
         Long newSeatId = seats.get(4).getId();
 
         mockMvc.perform(post("/api/seats/{seatId}/hold", newSeatId)
@@ -469,5 +448,217 @@ class SeatHoldControllerTest {
                                 {"showId": %d}
                                 """.formatted(showId)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void hold_multiSeat_bundleSizeGrows() throws Exception {
+        // 좌석을 추가할수록 bundle SCARD가 증가하는지 확인
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
+
+        long showId = 1L;
+        List<Seat> seats = createSeats(showId, 3);
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
+
+        for (int i = 0; i < 3; i++) {
+            Long seatId = seats.get(i).getId();
+
+            mockMvc.perform(post("/api/seats/{seatId}/hold", seatId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"showId": %d}
+                                    """.formatted(showId)))
+                    .andExpect(status().isOk());
+
+            Long bundleSize = stringRedisTemplate.opsForSet().size(bundleKey);
+            Assertions.assertEquals(i + 1, bundleSize);
+        }
+    }
+
+    /**
+     * 테스트 목적:
+     * 서로 다른 20명의 사용자가 동시에 같은 좌석에 HOLD 요청을 보낼 때
+     * Lua Script의 SET NX 원자성 덕분에 정확히 1명만 성공해야 한다.
+     *
+     * 기대 결과:
+     * - HTTP 200 성공 응답 = 정확히 1건
+     * - HTTP 409 충돌 응답 = 나머지 19건
+     * - Redis seatKey에 owner가 1명만 기록됨
+     */
+    @Test
+    void hold_concurrentSameSeats_onlyOneSucceeds() throws Exception {
+        int threadCount = 20;
+        long showId = 1L;
+        Seat seat = createSeat(showId, 1);
+        Long seatId = seat.getId();
+
+        // 사용자 생성 및 토큰 발급은 순차적으로
+        List<String> tokens = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            saveUser("concurrent" + i + "@test.com");
+            tokens.add(loginAndGetToken("concurrent" + i + "@test.com"));
+        }
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(threadCount);
+        AtomicInteger successCount  = new AtomicInteger(0);
+        AtomicInteger conflictCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (String token : tokens) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    int status = mockMvc.perform(
+                                    post("/api/seats/{seatId}/hold", seatId)
+                                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .content("""
+                                                    {"showId": %d}
+                                                    """.formatted(showId))
+                            )
+                            .andReturn()
+                            .getResponse()
+                            .getStatus();
+
+                    if (status == 200) successCount.incrementAndGet();
+                    else if (status == 409) conflictCount.incrementAndGet();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // 전 스레드 동시 출발
+        doneLatch.await(15, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // 정확히 1명만 성공
+        Assertions.assertEquals(1, successCount.get(), "hold 성공은 정확히 1건이어야 한다");
+        Assertions.assertEquals(threadCount - 1, conflictCount.get());
+
+        // Redis seatKey owner 확인
+        String owner = stringRedisTemplate.opsForValue().get(HoldKey.of(showId, seatId));
+        Assertions.assertNotNull(owner, "hold 성공한 사람의 seatKey가 Redis에 있어야 한다");
+    }
+
+    /**
+     * 테스트 목적:
+     * 같은 사용자가 10개의 서로 다른 좌석에 동시에 HOLD 요청을 보낼 때
+     * Lua Script의 SCARD → SADD 원자적 실행 덕분에 bundle 최대 4석 제한이 깨지지 않아야 한다.
+     *
+     * 기대 결과:
+     * - HTTP 200 성공 응답 = 정확히 4건
+     * - HTTP 409 충돌 응답 = 나머지 6건 (HOLD_LIMIT_EXCEEDED)
+     * - Redis bundle SCARD = 4
+     */
+    @Test
+    void hold_concurrentExceedLimit_exactlyFourSucceed() throws Exception {
+        int threadCount = 10;
+        long showId = 1L;
+
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
+        List<Seat> seats = createSeats(showId, threadCount);
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(threadCount);
+        AtomicInteger successCount      = new AtomicInteger(0);
+        AtomicInteger limitExceededCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (Seat seat : seats) {
+            Long seatId = seat.getId();
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    int status = mockMvc.perform(
+                                    post("/api/seats/{seatId}/hold", seatId)
+                                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .content("""
+                                                    {"showId": %d}
+                                                    """.formatted(showId))
+                            )
+                            .andReturn()
+                            .getResponse()
+                            .getStatus();
+
+                    if (status == 200) successCount.incrementAndGet();
+                    else if (status == 409) limitExceededCount.incrementAndGet();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await(15, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // 정확히 4석만 성공
+        Assertions.assertEquals(4, successCount.get(), "bundle 최대 4석 제한이 지켜져야 한다");
+        Assertions.assertEquals(threadCount - 4, limitExceededCount.get());
+
+        // bundle SCARD 직접 확인
+        Long bundleSize = stringRedisTemplate.opsForSet().size(bundleKey);
+        Assertions.assertEquals(4L, bundleSize, "bundle에 정확히 4개의 seatId가 있어야 한다");
+    }
+
+    /**
+     * 테스트 목적:
+     * 두 번째 이후 좌석을 HOLD할 때 해당 seatKey의 TTL이
+     * 새로운 300초가 아닌 bundle의 남은 TTL과 동기화되는지 확인한다.
+     * Lua Script의 PTTL 분기(isFirstSeat=0 경로)가 실제로 동작하는지 검증한다.
+     *
+     * 기대 결과:
+     * - 첫 번째 좌석 hold 후 bundle TTL을 150초로 강제 조정
+     * - 두 번째 좌석 hold 시 seatKey TTL ≈ 150초 (5초 오차 허용)
+     * - 300초가 아닌 남은 세션 시간에 맞춰져야 한다
+     */
+    @Test
+    void hold_secondSeat_ttlSyncedToBundle() throws Exception {
+        User user = saveUser("user@test.com");
+        String token = loginAndGetToken("user@test.com");
+
+        long showId = 1L;
+        List<Seat> seats = createSeats(showId, 2);
+        Long seatId1 = seats.get(0).getId();
+        Long seatId2 = seats.get(1).getId();
+        String bundleKey = HoldKey.bundleOf(showId, user.getId());
+        String seat2Key  = HoldKey.of(showId, seatId2);
+
+        // 첫 번째 좌석 hold (bundle TTL = 300s로 시작)
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId1)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isOk());
+
+        // bundle TTL을 150초로 강제 조정 (남은 세션 시간을 임의로 줄임)
+        stringRedisTemplate.expire(bundleKey, 150, TimeUnit.SECONDS);
+
+        // 두 번째 좌석 hold
+        mockMvc.perform(post("/api/seats/{seatId}/hold", seatId2)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"showId": %d}
+                                """.formatted(showId)))
+                .andExpect(status().isOk());
+
+        // seat2 TTL이 bundle 남은 TTL(≈150s)에 맞춰졌는지 확인 (5초 오차 허용)
+        Long seat2Ttl = stringRedisTemplate.getExpire(seat2Key, TimeUnit.SECONDS);
+        Assertions.assertNotNull(seat2Ttl);
+        Assertions.assertTrue(seat2Ttl >= 145 && seat2Ttl <= 150,
+                "seat2 TTL(%ds)이 bundle 남은 TTL(≈150s)과 동기화되어야 한다".formatted(seat2Ttl));
     }
 }


### PR DESCRIPTION
- HoldKey: bundleOf(showId, userId) 추가 — hold:bundle:{showId}:{userId} 키 패턴
- HoldRedisRepository: Lua Script(PTTL→SCARD→SET NX PX→SADD→EXPIRE)로 원자적 선점 처리, 기존 hold:user 관련 메서드 제거
- SeatHoldService: Lua Script 반환 코드로 예외 매핑, cancelHold에서 bundle 비면 bundleKey 삭제
- ReservationService: confirm() → confirmAll()로 교체, bundle SMEMBERS 기반 일괄 저장, afterCommit에서 Redis 정리, flush()로 UNIQUE 위반 즉시 표면화
- ReservationConfirmRequest: seatId 제거, showId만 유지
- ReservationConfirmResponse: seatId → reservedSeatIds: List<Long>
- ErrorCode: SESSION_EXPIRED 추가
- SeatHoldControllerTest: bundle 키 검증 추가, 동시성 테스트 3개 추가 (SET NX 원자성, SCARD→SADD 원자성, PTTL TTL 동기화)
- ReservationConfirmControllerTest: bundle 기반 전면 재작성, 다중 좌석 확정·Redis 정리·부분 롤백 테스트 추가


자세한 설명은 이슈 #69 확인