### PR TITLE
feat: 홈/좌석선택/내예약 화면에 로그아웃 버튼 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## [Unreleased]
 
 ### Added
+- 프론트엔드 로그아웃 UI(`components/layout/Header`) — 홈/좌석 선택/내 예약 화면에 인증 상태에 따라 로그인 링크 또는 로그아웃 버튼 표시. 기존 `useLogout` 훅은 있었으나 호출하는 UI가 없던 문제 수정. 리다이렉트 없이 인증 상태만 확인하는 `hooks/useAuthStatus` 추가
 - 좌석 선택 페이지(`/shows/[showId]/seats`), 내 예약 페이지(`/my/reservations`)에 홈으로 돌아가는 뒤로 가기 버튼(`components/ui/BackHomeButton`) 추가
 - 프론트엔드 "내 예약 조회/취소" 화면(`/my/reservations`) — `useMyReservations`/`useReservationCancel` 훅, `ReservationList`/`ReservationItem` 컴포넌트. 홈 화면에 진입 링크 추가
 - 프로젝트 전용 verify 하네스(`.claude/skills/verify/SKILL.md`) — backend/frontend 빌드·구동·hold-confirm 흐름·auth 흐름(로그인/refresh rotation/탈취 감지) 검증 레시피

--- a/frontend/src/app/my/reservations/page.tsx
+++ b/frontend/src/app/my/reservations/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { BackHomeButton } from '@/components/ui/BackHomeButton';
+import { Header } from '@/components/layout/Header';
 import { ReservationList } from '@/features/reservation/components/ReservationList';
 
 export default function MyReservationsPage() {
@@ -10,7 +11,10 @@ export default function MyReservationsPage() {
   if (isChecking) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
-        <BackHomeButton />
+        <div className="mb-4 flex items-center justify-between">
+          <BackHomeButton />
+          <Header />
+        </div>
         <div className="flex h-48 items-center justify-center text-sm text-zinc-500">
           인증 확인 중...
         </div>
@@ -20,7 +24,10 @@ export default function MyReservationsPage() {
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-8">
-      <BackHomeButton />
+      <div className="mb-4 flex items-center justify-between">
+        <BackHomeButton />
+        <Header />
+      </div>
       <h1 className="mb-6 text-xl font-semibold text-foreground">내 예약</h1>
       <ReservationList />
     </main>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,13 @@
 import Link from 'next/link';
+import { Header } from '@/components/layout/Header';
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-4">
+    <main className="relative flex min-h-screen flex-col items-center justify-center px-4">
+      <div className="absolute right-4 top-4">
+        <Header />
+      </div>
+
       <span className="mb-4 text-4xl" aria-hidden>
         ⚾
       </span>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuthStatus } from '@/hooks/useAuthStatus';
+import { useLogout } from '@/features/auth/hooks/useLogout';
+
+export function Header() {
+  const { isAuthenticated, isChecking } = useAuthStatus();
+  const { mutate: logout, isPending } = useLogout();
+
+  if (isChecking) return null;
+
+  if (!isAuthenticated) {
+    return (
+      <Link href="/login" className="text-sm text-zinc-400 hover:text-stadium-gold">
+        로그인
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => logout()}
+      disabled={isPending}
+      className="text-sm text-zinc-400 hover:text-stadium-gold disabled:opacity-50"
+    >
+      {isPending ? '로그아웃 중...' : '로그아웃'}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/BackHomeButton.tsx
+++ b/frontend/src/components/ui/BackHomeButton.tsx
@@ -4,7 +4,7 @@ export function BackHomeButton() {
   return (
     <Link
       href="/"
-      className="mb-4 inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-stadium-gold"
+      className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-stadium-gold"
     >
       <span aria-hidden>←</span> 홈으로
     </Link>

--- a/frontend/src/features/seat/components/SeatsView.tsx
+++ b/frontend/src/features/seat/components/SeatsView.tsx
@@ -5,6 +5,7 @@ import { useSeats } from '@/features/seat/hooks/useSeats';
 import { useSeatHold } from '@/features/seat/hooks/useSeatHold';
 import { useReservationConfirm } from '@/features/seat/hooks/useReservationConfirm';
 import { BackHomeButton } from '@/components/ui/BackHomeButton';
+import { Header } from '@/components/layout/Header';
 import { getZoneStyle } from '@/shared/utils/zoneColor';
 import { SeatGrid } from './SeatGrid';
 import { HoldTimer } from './HoldTimer';
@@ -94,7 +95,10 @@ export function SeatsView({ showId }: SeatsViewProps) {
   if (isLoading) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
-        <BackHomeButton />
+        <div className="mb-4 flex items-center justify-between">
+          <BackHomeButton />
+          <Header />
+        </div>
         <div className="flex h-48 items-center justify-center text-sm text-zinc-500">
           좌석 불러오는 중...
         </div>
@@ -105,7 +109,10 @@ export function SeatsView({ showId }: SeatsViewProps) {
   if (isError) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
-        <BackHomeButton />
+        <div className="mb-4 flex items-center justify-between">
+          <BackHomeButton />
+          <Header />
+        </div>
         <div className="flex h-48 items-center justify-center text-sm text-red-400">
           좌석 정보를 불러오지 못했습니다.
         </div>
@@ -116,7 +123,10 @@ export function SeatsView({ showId }: SeatsViewProps) {
   if (!seats?.length) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
-        <BackHomeButton />
+        <div className="mb-4 flex items-center justify-between">
+          <BackHomeButton />
+          <Header />
+        </div>
         <div className="flex h-48 items-center justify-center text-sm text-zinc-500">
           등록된 좌석이 없습니다.
         </div>
@@ -126,7 +136,10 @@ export function SeatsView({ showId }: SeatsViewProps) {
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-8 pb-24">
-      <BackHomeButton />
+      <div className="mb-4 flex items-center justify-between">
+        <BackHomeButton />
+        <Header />
+      </div>
       <h1 className="mb-1 text-xl font-semibold text-foreground">좌석 선택</h1>
       <p className="mb-6 text-xs text-zinc-500">5초마다 자동으로 갱신됩니다.</p>
 

--- a/frontend/src/hooks/useAuthStatus.ts
+++ b/frontend/src/hooks/useAuthStatus.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/store/auth.store';
+import { refreshApi } from '@/api/auth.api';
+
+export function useAuthStatus() {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const setAccessToken = useAuthStore((s) => s.setAccessToken);
+  const [isChecking, setIsChecking] = useState(!accessToken);
+
+  useEffect(() => {
+    if (accessToken) {
+      return;
+    }
+
+    // 리다이렉트 없이 refresh 쿠키로만 복원 시도 — 실패하면 그냥 비로그인 상태로 둔다.
+    refreshApi()
+      .then((data) => setAccessToken(data.accessToken))
+      .catch(() => {})
+      .finally(() => setIsChecking(false));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { isAuthenticated: accessToken !== null, isChecking };
+}


### PR DESCRIPTION
## Summary
- 백엔드/useLogout 훅은 있었지만 호출하는 UI가 없어 로그아웃이 불가능했던 문제 수정
- 리다이렉트 없이 인증 상태만 조용히 확인하는 useAuthStatus 훅 추가
- 인증 상태에 따라 로그인 링크/로그아웃 버튼을 보여주는 Header 컴포넌트 추가, 홈/좌석선택/내예약 3개 화면에 삽입

## Test plan
- [x] npm run test (9 files / 33 tests 통과)
- [x] npm run lint
- [x] 브라우저에서 로그인 링크 → 로그인 → 로그아웃 버튼 클릭 → /login 이동 확인