### PR TITLE
fix: 로그인/회원가입 입력창 브라우저 자동완성 배경색 오버라이드

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -27,3 +27,17 @@ body {
   font-family: var(--font-sans);
   min-height: 100%;
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--foreground);
+  -webkit-box-shadow: 0 0 0 1000px var(--background) inset;
+  box-shadow: 0 0 0 1000px var(--background) inset;
+  transition: background-color 9999s ease-in-out 0s;
+}
+
+input:autofill {
+  background-color: var(--background);
+  color: var(--foreground);
+}


### PR DESCRIPTION
Chrome 등이 -webkit-autofill 상태의 input에 강제로 밝은 배경색을 씌워 다크 테마와 충돌하던 문제 수정. box-shadow inset 트릭으로 자동완성 시에도
배경/글자색이 다크 테마를 유지하도록 함.