### PR TITLE
feat: 회원가입 전화번호 입력 숫자 제한 및 자동 하이픈 포맷팅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## [Unreleased]
 
 ### Added
+- 회원가입 화면 전화번호 입력에 숫자만 입력되도록 제한하고 `010-1234-5678` 형식으로 자동 하이픈 삽입 (`shared/utils/phone.ts`)
 - 프론트엔드 로그아웃 UI(`components/layout/Header`) — 홈/좌석 선택/내 예약 화면에 인증 상태에 따라 로그인 링크 또는 로그아웃 버튼 표시. 기존 `useLogout` 훅은 있었으나 호출하는 UI가 없던 문제 수정. 리다이렉트 없이 인증 상태만 확인하는 `hooks/useAuthStatus` 추가
 - 좌석 선택 페이지(`/shows/[showId]/seats`), 내 예약 페이지(`/my/reservations`)에 홈으로 돌아가는 뒤로 가기 버튼(`components/ui/BackHomeButton`) 추가
 - 프론트엔드 "내 예약 조회/취소" 화면(`/my/reservations`) — `useMyReservations`/`useReservationCancel` 훅, `ReservationList`/`ReservationItem` 컴포넌트. 홈 화면에 진입 링크 추가

--- a/frontend/src/features/auth/components/SignupForm.tsx
+++ b/frontend/src/features/auth/components/SignupForm.tsx
@@ -8,6 +8,7 @@ import type { AxiosError } from 'axios';
 import { useSignup } from '@/features/auth/hooks/useSignup';
 import { signupSchema, type SignupFormValues } from '@/features/auth/schemas/auth.schema';
 import type { ErrorResponse } from '@/types/api.types';
+import { formatPhoneNumber } from '@/shared/utils/phone';
 
 export function SignupForm() {
   const { mutate: signup, isPending } = useSignup();
@@ -36,6 +37,8 @@ export function SignupForm() {
   function clearServerError() {
     if (serverError) setServerError(null);
   }
+
+  const phoneField = register('phone', { onChange: clearServerError });
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
@@ -104,8 +107,14 @@ export function SignupForm() {
             <input
               id="phone"
               type="tel"
+              inputMode="numeric"
+              maxLength={13}
               autoComplete="tel"
-              {...register('phone', { onChange: clearServerError })}
+              {...phoneField}
+              onChange={(e) => {
+                e.target.value = formatPhoneNumber(e.target.value);
+                phoneField.onChange(e);
+              }}
               className="w-full rounded-md border border-white/15 bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-stadium-gold focus:ring-1 focus:ring-stadium-gold"
             />
             {errors.phone && (

--- a/frontend/src/features/auth/schemas/auth.schema.ts
+++ b/frontend/src/features/auth/schemas/auth.schema.ts
@@ -15,7 +15,10 @@ export const signupSchema = z.object({
     .email('올바른 이메일 형식이어야 합니다.'),
   password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
   name: z.string().min(1, '이름은 필수입니다.'),
-  phone: z.string().min(1, '전화번호는 필수입니다.'),
+  phone: z
+    .string()
+    .min(1, '전화번호는 필수입니다.')
+    .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, '올바른 전화번호 형식이 아닙니다.'),
 });
 
 export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/frontend/src/shared/utils/phone.test.ts
+++ b/frontend/src/shared/utils/phone.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatPhoneNumber } from './phone';
+
+describe('formatPhoneNumber', () => {
+  it('숫자가 3자리 이하면 그대로 반환한다', () => {
+    expect(formatPhoneNumber('010')).toBe('010');
+  });
+
+  it('4~7자리면 3-n 형식으로 하이픈을 넣는다', () => {
+    expect(formatPhoneNumber('01012')).toBe('010-12');
+    expect(formatPhoneNumber('0101234')).toBe('010-1234');
+  });
+
+  it('8자리 이상이면 3-4-4 형식으로 하이픈을 넣는다', () => {
+    expect(formatPhoneNumber('01012345678')).toBe('010-1234-5678');
+  });
+
+  it('숫자가 아닌 문자는 제거한다', () => {
+    expect(formatPhoneNumber('010-abc1234-5678')).toBe('010-1234-5678');
+  });
+
+  it('11자리를 초과하는 입력은 잘라낸다', () => {
+    expect(formatPhoneNumber('010123456789999')).toBe('010-1234-5678');
+  });
+});

--- a/frontend/src/shared/utils/phone.ts
+++ b/frontend/src/shared/utils/phone.ts
@@ -1,0 +1,7 @@
+export function formatPhoneNumber(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 11);
+
+  if (digits.length < 4) return digits;
+  if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+}


### PR DESCRIPTION
## Summary
- 전화번호 입력에 숫자가 아닌 문자가 그대로 입력되던 문제 수정
- 숫자만 추출해 010-1234-5678(3-4-4) 형식으로 자동 하이픈 삽입
- Zod 스키마에 형식 검증(정규식) 추가로 붙여넣기 등 예외 케이스 방어

## Test plan
- [x] npm run test (10 files / 38 tests 통과, phone.test.ts 5개 신규)
- [x] npm run lint
- [x] 브라우저에서 회원가입 전화번호 칸 직접 타이핑 확인