### PR TITLE
feat: 좌석 조회 API(GET /api/seats) 인증 필수화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - 백엔드 로깅/민감정보 마스킹 규칙(`backend/AGENTS.md`)
 
 ### Changed
+- `GET /api/seats` 좌석 조회 API를 인증 필수로 전환 (기존 공개 API였음) — 비로그인 조회는 401, 프론트엔드는 기존 axios 401 인터셉터로 자동 리다이렉트
 - 프론트엔드 전체 UI를 다크 톤의 야구장 예매 사이트 컨셉으로 리디자인 — 홈/좌석 선택/내 예약/로그인/회원가입 화면, 좌석 선택 화면에 구역(zone)별 색상과 필드뷰 다이어그램 추가
 - `backend/CLAUDE.md`를 `@AGENTS.md` 포인터로 전환, 실제 내용은 `backend/AGENTS.md`로 이동 (root/frontend와 패턴 통일)
 - README의 API 목록/Redis 키 구조/토큰 설계 이유를 도메인 문서 링크로 축약 (중복 제거)

--- a/backend/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
+++ b/backend/src/main/java/com/demo/seatreservation/seat/CLAUDE.md
@@ -12,7 +12,7 @@ HOLD는 **예매 세션(showId + userId) 단위**로 묶여서 관리된다 (`re
 |--------|------|------|------|
 | POST | `/api/seats/{seatId}/hold` | 필요 (적용) | HOLD 생성 (예매 세션에 좌석 1개 추가) |
 | DELETE | `/api/seats/{seatId}/hold` | 필요 (적용) | HOLD 취소 (좌석 1개를 세션에서 제거) |
-| GET | `/api/seats` | 불필요 (GET `/api/seats` 공개) | 실시간 좌석 상태 조회 (`?showId=` 쿼리 파라미터) |
+| GET | `/api/seats` | 필요 (적용) | 실시간 좌석 상태 조회 (`?showId=` 쿼리 파라미터) |
 | POST | `/api/reservations/confirm` | 필요 (적용) | 예매 세션 내 HOLD된 좌석 **전체 일괄** 확정 |
 | GET | `/api/me/reservations` | 필요 (적용) | 내 예약 조회 (userId는 JWT Principal에서 추출) |
 | POST | `/api/reservations/{reservationId}/cancel` | 필요 (적용) | 예약 취소 |

--- a/backend/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/demo/seatreservation/security/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/refresh"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/shows/**", "/api/seats", "/", "/health").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/shows/**", "/", "/health").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/test/java/com/demo/seatreservation/seat/controller/SeatQueryControllerTest.java
+++ b/backend/src/test/java/com/demo/seatreservation/seat/controller/SeatQueryControllerTest.java
@@ -2,9 +2,12 @@ package com.demo.seatreservation.seat.controller;
 
 import com.demo.seatreservation.domain.Reservation;
 import com.demo.seatreservation.domain.Seat;
+import com.demo.seatreservation.domain.User;
 import com.demo.seatreservation.domain.enums.ReservationStatus;
+import com.demo.seatreservation.domain.enums.Role;
 import com.demo.seatreservation.repository.ReservationRepository;
 import com.demo.seatreservation.repository.SeatRepository;
+import com.demo.seatreservation.repository.UserRepository;
 import com.demo.seatreservation.seat.redis.HoldKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,12 +16,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -36,8 +47,19 @@ class SeatQueryControllerTest {
     @Autowired
     StringRedisTemplate redisTemplate;
 
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private String token;
+
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
 
         // DB 예약 데이터 초기화
         reservationRepository.deleteAll();
@@ -49,6 +71,9 @@ class SeatQueryControllerTest {
 
         // Seat 테이블 초기화
         seatRepository.deleteAll();
+
+        // User 테이블 초기화
+        userRepository.deleteAll();
 
         // 테스트용 좌석 3개 생성
         seatRepository.save(Seat.builder()
@@ -71,6 +96,37 @@ class SeatQueryControllerTest {
                 .row(1)
                 .number(3)
                 .build());
+
+        // 좌석 조회는 인증이 필요하므로 테스트용 유저 발급
+        saveUser("query@test.com");
+        token = loginAndGetToken("query@test.com");
+    }
+
+    private void saveUser(String email) {
+        userRepository.save(
+                User.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode("password1!"))
+                        .name("테스터")
+                        .phone("010-0000-0000")
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    private String loginAndGetToken(String email) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"email": "%s", "password": "password1!"}
+                                        """.formatted(email))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get("data").get("accessToken").asText();
     }
 
 
@@ -87,12 +143,29 @@ class SeatQueryControllerTest {
     void getSeats_allAvailable() throws Exception {
 
         mockMvc.perform(get("/api/seats")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .param("showId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
                 .andExpect(jsonPath("$.data[1].status").value("AVAILABLE"))
                 .andExpect(jsonPath("$.data[2].status").value("AVAILABLE"));
+    }
+
+
+    /**
+     * 테스트 목적:
+     * 인증 토큰 없이 좌석 조회를 시도하면 401을 반환하는지 확인한다.
+     *
+     * 기대 결과:
+     * - HTTP 401 Unauthorized
+     */
+    @Test
+    void getSeats_noAuthToken_returns401() throws Exception {
+
+        mockMvc.perform(get("/api/seats")
+                        .param("showId", "1"))
+                .andExpect(status().isUnauthorized());
     }
 
 
@@ -119,6 +192,7 @@ class SeatQueryControllerTest {
                 .set(key, "100", 300, TimeUnit.SECONDS);
 
         mockMvc.perform(get("/api/seats")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .param("showId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].status").value("HELD"));
@@ -151,6 +225,7 @@ class SeatQueryControllerTest {
         );
 
         mockMvc.perform(get("/api/seats")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .param("showId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].status").value("RESERVED"));
@@ -200,6 +275,7 @@ class SeatQueryControllerTest {
         redisTemplate.opsForValue().set(key, "100");
 
         mockMvc.perform(get("/api/seats")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                         .param("showId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].status").value("RESERVED"));

--- a/frontend/FRONTEND.md
+++ b/frontend/FRONTEND.md
@@ -376,7 +376,7 @@ useMutation({
 | 홈 | `/` | 불필요 | — |
 | 로그인 | `/login` | 불필요 (로그인 시 홈으로) | — |
 | 회원가입 | `/signup` | 불필요 | — |
-| 좌석 선택 | `/shows/[showId]/seats` | 조회: 불필요 / HOLD: 필요 | HOLD 시도 시 /login |
+| 좌석 선택 | `/shows/[showId]/seats` | 조회: 필요 / HOLD: 필요 | 비로그인 시 조회 API가 401 → axios 인터셉터가 refresh 시도 후 실패하면 /login으로 리다이렉트 (별도 `useRequireAuth` 가드 없이 인터셉터에 의존) |
 | 내 예약 | `/my/reservations` | 필요 | /login 리다이렉트 |
 
 ### 인증 보호 구현 방식


### PR DESCRIPTION
트래픽 몰릴 때 익명 폴링으로 인한 부하를 줄이기 위해 비로그인 조회를 차단한다.
프론트엔드는 기존 axios 401 인터셉터(refresh 시도 후 실패 시 /login 리다이렉트)로 별도 코드 변경 없이 대응한다.